### PR TITLE
For legacy_root, ensure that template class is added to #x-root

### DIFF
--- a/tmpl/base_root.tmpl
+++ b/tmpl/base_root.tmpl
@@ -51,7 +51,7 @@ Below is your base template file, which is extended by home.tmpl:
             });
         {/script}
         {%script}
-            Mobify.$('html, #x-root').last().addClass("{#content.templateName}x-{.}{~s}{/content.templateName}");
+            Mobify.$('html').addClass("{#content.templateName}x-{.}{~s}{/content.templateName}");
         {/script}    
     {/baseScripts}
     {+head}

--- a/tmpl/legacy_root.tmpl
+++ b/tmpl/legacy_root.tmpl
@@ -13,7 +13,7 @@
             });
         {/script}
         {%script}
-            Mobify.$('html, #x-root').last().addClass("{#content.templateName}x-{.}{~s}{/content.templateName}");
+            Mobify.$('html').last().addClass("{#content.templateName}x-{.}{~s}{/content.templateName}");
         {/script}    
     {/baseScripts}
     {+head}
@@ -24,7 +24,7 @@
 </head>
 {$body|openTag|s}
     {+body}
-    <section id="x-root">
+    <section id="x-root" class="{#content.templateName}x-{.}{~s}{/content.templateName}">
         {+header}{>_header/}{/header}
         <section id="x-main">{+content}{$body|innerHTML|s}{/content}</section>
         {+footer}{>_footer/}{/footer}

--- a/tmpl/legacy_root.tmpl
+++ b/tmpl/legacy_root.tmpl
@@ -1,21 +1,36 @@
-{>base_root/}
-
-{<head}
-    {%script}
-        Mobify.$('html').removeClass("{#content.templateName}x-{.}{~s}{/content.templateName}");
-    {/script}    
-
-    {#mobileViewport}<meta name="viewport" content="{.|s}" />{/mobileViewport}
-    {#touchIcon}<link rel="apple-touch-icon" href="{imageDir|s}{.|s}" />{/touchIcon}
-    {#formatDetection}<meta name="format-detection" content="{.|s}" />{/formatDetection}
-    {+style}{#config}<link rel="stylesheet" type="text/css" href="{cssDir}stylesheet.css" />{/config}{/style}
-    {$head|innerHTML|s}
-{/head}
-
-{<body}
-    <section id="x-root" class="{#content.templateName}x-{.}{~s}{/content.templateName}">
+{doctype|s}
+{$html|openTag|s}
+{$head|openTag|s}
+    {+baseScripts}
+        {#lib_import/}
+        {%script}
+            Mobify.enhance();
+            // Scroll the page past URL bar if user did not scroll manually, and hash is absent.
+            Mobify.$(this).bind('load', function() {
+                location.hash || setTimeout(function() {
+                    pageYOffset || scrollTo(0, 1);
+                }, 250);
+            });
+        {/script}
+        {%script}
+            Mobify.$('html, #x-root').last().addClass("{#content.templateName}x-{.}{~s}{/content.templateName}");
+        {/script}    
+    {/baseScripts}
+    {+head}
+        {$head|innerHTML|s}
+        <link rel="stylesheet" href="{config.configDir}style.css" />
+        <meta name="viewport" content="width=device-width; initial-scale=1.0; minimum-scale=1.0; maximum-scale=1.0; user-scalable=no;" />
+    {/head}
+</head>
+{$body|openTag|s}
+    {+body}
+    <section id="x-root">
         {+header}{>_header/}{/header}
         <section id="x-main">{+content}{$body|innerHTML|s}{/content}</section>
         {+footer}{>_footer/}{/footer}
     </section>
-{/body}
+    {/body}
+    {+scripts}
+    {/scripts}
+</body>
+</html>

--- a/tmpl/legacy_root.tmpl
+++ b/tmpl/legacy_root.tmpl
@@ -1,6 +1,10 @@
 {>base_root/}
 
 {<head}
+    {%script}
+        Mobify.$('html').removeClass("{#content.templateName}x-{.}{~s}{/content.templateName}");
+    {/script}    
+
     {#mobileViewport}<meta name="viewport" content="{.|s}" />{/mobileViewport}
     {#touchIcon}<link rel="apple-touch-icon" href="{imageDir|s}{.|s}" />{/touchIcon}
     {#formatDetection}<meta name="format-detection" content="{.|s}" />{/formatDetection}
@@ -9,7 +13,7 @@
 {/head}
 
 {<body}
-    <section id="x-root">
+    <section id="x-root" class="{#content.templateName}x-{.}{~s}{/content.templateName}">
         {+header}{>_header/}{/header}
         <section id="x-main">{+content}{$body|innerHTML|s}{/content}</section>
         {+footer}{>_footer/}{/footer}


### PR DESCRIPTION
Executing `Mobify.$('html, #x-root').last()` from within the `<head>` would always give you the html element because #x-root has not existed yet.
