### PR TITLE
Correctly reset the mobify-path cookie for Mobify.desktop()

### DIFF
--- a/api/util.js
+++ b/api/util.js
@@ -5,7 +5,7 @@
 //
 // `url`: Optional url to redirect to after opting out.
 Mobify.desktop = function(url) {
-    document.cookie = 'mobify-path; path=/;';
+    document.cookie = 'mobify-path=; path=/;';
 
     if (url) {
         location = url;


### PR DESCRIPTION
Calling `Mobify.desktop()` didn't reset `mobify-path` cookie.  Thus, you kept seeing the mobile view.

@tedtate has fixed this a month ago for 1.0 tag but the update wasn't brought in to 1.1.
