### PR TITLE
Removing templateName from html element in legacyRoot

### DIFF
--- a/tmpl/legacy_root.tmpl
+++ b/tmpl/legacy_root.tmpl
@@ -12,9 +12,6 @@
                 }, 250);
             });
         {/script}
-        {%script}
-            Mobify.$('html').last().addClass("{#content.templateName}x-{.}{~s}{/content.templateName}");
-        {/script}    
     {/baseScripts}
     {+head}
         {$head|innerHTML|s}


### PR DESCRIPTION
Previous pull request missed this one commit to update legacy_root template.
