### PR TITLE
Restore Mobify.desktop() for non-webkit browsers

### DIFF
--- a/konf/base.konf
+++ b/konf/base.konf
@@ -22,9 +22,12 @@
     {>"/base/vendor/slide.js"/}
 {/lib}{/lib_export}
 
+{#lib_export name="util"}
+    {>"/base/api/util.js"/}
+{/lib_export}
+
 {>"/base/api/persistHash.js"/}
 {>"/base/api/logging.js"/}
-{>"/base/api/util.js"/}
 {>"/base/api/timing.js"/}
 {>"/base/api/externals.js"/}
 {>"/base/api/extractHTML.js"/}


### PR DESCRIPTION
By storing 'api/util.js' in the ark.
