### PR TITLE
New documentation in place for review.

### DIFF
--- a/docs/appendix.md
+++ b/docs/appendix.md
@@ -7,79 +7,70 @@
 2. Common Errors
 3. Dust.js Documentation
 
-
-1. Debugging
+# Debugging
 
 ## Tools
 
-Debugging Mobify.js adaptations requires the use of an advanced web inspection tool like Webkit Inspector or Firebug. You're likely well-acquainted with one of these, but here are a few quick start tips if not.
+Debugging Mobify.js adaptations requires the use of a web inspection tool like Webkit Inspector or Firebug. You're likely well-acquainted with one of these, but here are a few quick start tips if not.
 
 **Webkit Inspector**
 
-Webkit Inspector is built in to Safari and Chrome. To initialize, open the browser's 'View' menu and select the Developer option. Opening either Developer Tools or JavaScript Console will pop up the Inspector.
+The Webkit Inspector is a powerful web development tool that is built into the Safari and Chrome browsers.
 
-If using Safari, you may have to first enable the development menu. Open Safari Preferences and select the Advanced tab, then check the development menu checkbox.
+To enable the inspector in Safari, open the Preferences pane, click Advanced, then select "Show Develop menu in menu bar". Open the inspector by right clicking on an element in a webpage and then selecting "Inspect Element".
 
-Once open, you can switch back and forth between JavaScript Console and DOM views with the 'Console' and 'Elements' tabs at top, respectively.
+In Chrome, open the inspector by right clicking on an element in a webpage and then selecting "Inspect Element".
 
-*Firebug*
+**Firebug**
 
-If you're using Firefox, you will need to [install Firebug] http://getfirebug.com/. Once installed, in the browser's 'View' menu, click the 'Firebug' option at the bottom to initialize.
+Firebug provides similiar behaviour to the WebKit Inspector in the Firefox browser. [Install the Firebug plugin.](http://getfirebug.com/). Once installed, in the browser's "View" menu, click the "Firebug" option at the bottom to initialize.
 
-Once open, you can switch back and forth between JavaScript Console and DOM views with the 'Console' and 'HTML' tabs at top, respectively.
-
-For more on getting started with Firebug, watch this [helpful video] http://www.youtube.com/watch?v=2xxfvuZFHsM
-
+For more on getting started with Firebug, watch this [helpful video](http://www.youtube.com/watch?v=2xxfvuZFHsM).
 
 ## Debugging the Konf
 
-Since the konf is written in JavaScript, you will often find syntax or logic errors springing up as you develop. The best way to debug the konf object is with the Webkit Inspector or the Firebug extension.
+The konf is written in JavaScript and you will often find syntax or logic errors springing up as you develop. The best way to debug the konf is with the Webkit Inspector or the Firebug extension.
 
-Once in development mode, you can view context (the result of the evaluated konf object) since it is logged to the JavaScript console. Look for a the item 'All Extracted Data', which you can expand to see exactly what values were assigned to which keys. **Note**: Extracted Data will not be present after you have published your mobile site, it can only be viewed by browsing your site through http://preview.mobify.com/
+In development mode, the result of the evaluated konf, the context, is logged to the JavaScript console. Look for a the item 'All Extracted Data', which can be expanded to show what values were assigned to what keys. **Note**: Extracted Data is only available in development mode, which can be activated by browsing your site through http://preview.mobify.com/
 
-If you are stumped you can add a `debugger;` statement into your konf object that will cause the inspector's debugger to pause as the konf is evaluated:
+If you are stumped, try adding a `debugger;` statement into your konf. This will cause the inspector's debugger to pause as the konf is evaluated:
 
-    'content': function(context) {
+    'content': function() {
         debugger;
-        return $('.content')
+        return $('.content');
     }
 
+You can then use the inspector to step through the execution of your konf.
 
 ## Debugging Templates (Viewing source, inspecting rendered DOM)
 
-Mobify.js adaptations are evaluated against the original DOM, but the latter is what you'll see if you view the page source. This isn't terribly helpful when you need insight into whether a particular adaptation is working or not.
+Mobify.js adaptations are evaluated against the source DOM. "View Source" shows the source DOM, not the result of the adaptation. In situations where you need to view the rendered DOM, use Firebug or the WebKit inspector. The DOM tab (labelled 'HTML' or 'Elements') displays a DOM tree that shows the adaptated DOM. Browse this tree to see the full result of the adaptation.
 
-In situations where you need to view the rendered DOM, use Firebug or the WebKit inspector.
+# Common Issues
 
-The DOM tab (labelled 'HTML' or 'Elements') displays a DOM tree that outlines the post-adaptation DOM. You are able to browse this tree and view the full result of the Mobify adaptation.
+Errors Mobify.js encounters during execution are logged to the JavaScript console. You can view these errors using Webkit Inspector or Firebug. If things don't appear to be working, we suggest starting there!
 
+* **Page is blank, doesn't render at all**
 
-## Common Errors
+    Usually this will be accompanied by the error message: "Uncaught SyntaxError: Unexpected string".
 
-Any errors Mobify.js encounters during execution will be logged in the Webkit Inspector / Firebug JavaScript Console. When things don't appear to be working, we suggest starting there.
+    SOLUTION: Ensure that you have a comma after every key within your konf, ie.
 
-* Page is blank, doesn't render at all
+        'header': {
+            ...
+        },
+        'content': {
 
-	Usually this will be accompanied by the error message: "Uncaught SyntaxError: Unexpected string".
+        },
 
-	SOLUTION: Ensure that you have a comma after every key within your konf, ie.
+* **{some-key} displayed on the page**
 
-	    'header': {
-	        ...
-	    },
-	    'content': {
-	
-	    },
+    When a variable is rendered to the page instead of parsed with data from your konf, this likely means you have used an illegal character in the key.
 
-* {some-key} displayed on the page
+    SOLUTION: Don't use illegal characters in keys. This includes almost all non-alphanumeric characters, ie. dashes (-), periods (.), commas (,), plus signs (+), etc.
 
-	When a variable is rendered to the page instead of parsed with data from your konf, this likely means you have used an illegal character in the key.
-	
-	SOLUTION: Don't use illegal characters in keys. This includes almost all non-alphanumeric characters, ie. dashes (-), periods (.), commas (,), plus signs (+), etc.
+# Dust.js Documentation
 
-
-## Dust.js Documentation
-
-Mobify.js templates extend the Dust.js JavaScript templating language. For more advanced examples of the syntax, you might find it helpful to browse the [Dust documentation] http://akdubya.github.com/dustjs/.
+Mobify.js templates extend the Dust.js JavaScript templating language. For more advanced examples of the syntax, you might find it helpful to browse the [Dust documentation](http://akdubya.github.com/dustjs/).
 
 You will likely find there to be differences in terminology and syntax, so we suggest making sure you're knowledgable about Mobify.js templates before doing so.

--- a/docs/appendix.md
+++ b/docs/appendix.md
@@ -60,22 +60,22 @@ Any errors Mobify.js encounters during execution will be logged in the Webkit In
 
 * Page is blank, doesn't render at all
 
-Usually this will be accompanied by the error message: "Uncaught SyntaxError: Unexpected string".
+	Usually this will be accompanied by the error message: "Uncaught SyntaxError: Unexpected string".
 
-SOLUTION: Ensure that you have a comma after every key within your konf, ie.
+	SOLUTION: Ensure that you have a comma after every key within your konf, ie.
 
-    'header': {
-        ...
-    },
-    'content': {
-
-    },
+	    'header': {
+	        ...
+	    },
+	    'content': {
+	
+	    },
 
 * {some-key} displayed on the page
 
-When a variable is rendered to the page instead of parsed with data from your konf, this likely means you have used an illegal character in the key.
-
-SOLUTION: Don't use illegal characters in keys. This includes almost all non-alphanumeric characters, ie. dashes (-), periods (.), commas (,), plus signs (+), etc.
+	When a variable is rendered to the page instead of parsed with data from your konf, this likely means you have used an illegal character in the key.
+	
+	SOLUTION: Don't use illegal characters in keys. This includes almost all non-alphanumeric characters, ie. dashes (-), periods (.), commas (,), plus signs (+), etc.
 
 
 ## Dust.js Documentation

--- a/docs/appendix.md
+++ b/docs/appendix.md
@@ -1,0 +1,85 @@
+# Appendix
+
+1. Debugging
+	- Tools
+	- Debugging the Konf
+	- Debugging Templates
+2. Common Errors
+3. Dust.js Documentation
+
+
+1. Debugging
+
+## Tools
+
+Debugging Mobify.js adaptations requires the use of an advanced web inspection tool like Webkit Inspector or Firebug. You're likely well-acquainted with one of these, but here are a few quick start tips if not.
+
+**Webkit Inspector**
+
+Webkit Inspector is built in to Safari and Chrome. To initialize, open the browser's 'View' menu and select the Developer option. Opening either Developer Tools or JavaScript Console will pop up the Inspector.
+
+If using Safari, you may have to first enable the development menu. Open Safari Preferences and select the Advanced tab, then check the development menu checkbox.
+
+Once open, you can switch back and forth between JavaScript Console and DOM views with the 'Console' and 'Elements' tabs at top, respectively.
+
+*Firebug*
+
+If you're using Firefox, you will need to [install Firebug] http://getfirebug.com/. Once installed, in the browser's 'View' menu, click the 'Firebug' option at the bottom to initialize.
+
+Once open, you can switch back and forth between JavaScript Console and DOM views with the 'Console' and 'HTML' tabs at top, respectively.
+
+For more on getting started with Firebug, watch this [helpful video] http://www.youtube.com/watch?v=2xxfvuZFHsM
+
+
+## Debugging the Konf
+
+Since the konf is written in JavaScript, you will often find syntax or logic errors springing up as you develop. The best way to debug the konf object is with the Webkit Inspector or the Firebug extension.
+
+Once in development mode, you can view context (the result of the evaluated konf object) since it is logged to the JavaScript console. Look for a the item 'All Extracted Data', which you can expand to see exactly what values were assigned to which keys. **Note**: Extracted Data will not be present after you have published your mobile site, it can only be viewed by browsing your site through http://preview.mobify.com/
+
+If you are stumped you can add a `debugger;` statement into your konf object that will cause the inspector's debugger to pause as the konf is evaluated:
+
+    'content': function(context) {
+        debugger;
+        return $('.content')
+    }
+
+
+## Debugging Templates (Viewing source, inspecting rendered DOM)
+
+Mobify.js adaptations are evaluated against the original DOM, but the latter is what you'll see if you view the page source. This isn't terribly helpful when you need insight into whether a particular adaptation is working or not.
+
+In situations where you need to view the rendered DOM, use Firebug or the WebKit inspector.
+
+The DOM tab (labelled 'HTML' or 'Elements') displays a DOM tree that outlines the post-adaptation DOM. You are able to browse this tree and view the full result of the Mobify adaptation.
+
+
+## Common Errors
+
+Any errors Mobify.js encounters during execution will be logged in the Webkit Inspector / Firebug JavaScript Console. When things don't appear to be working, we suggest starting there.
+
+* Page is blank, doesn't render at all
+
+Usually this will be accompanied by the error message: "Uncaught SyntaxError: Unexpected string".
+
+SOLUTION: Ensure that you have a comma after every key within your konf, ie.
+
+    'header': {
+        ...
+    },
+    'content': {
+
+    },
+
+* {some-key} displayed on the page
+
+When a variable is rendered to the page instead of parsed with data from your konf, this likely means you have used an illegal character in the key.
+
+SOLUTION: Don't use illegal characters in keys. This includes almost all non-alphanumeric characters, ie. dashes (-), periods (.), commas (,), plus signs (+), etc.
+
+
+## Dust.js Documentation
+
+Mobify.js templates extend the Dust.js JavaScript templating language. For more advanced examples of the syntax, you might find it helpful to browse the [Dust documentation] http://akdubya.github.com/dustjs/.
+
+You will likely find there to be differences in terminology and syntax, so we suggest making sure you're knowledgable about Mobify.js templates before doing so.

--- a/docs/appendix.md
+++ b/docs/appendix.md
@@ -1,13 +1,14 @@
+---
+layout: doc
+title: Appendix
+---
+
 # Appendix
 
-1. Debugging
-    - Tools
-    - Debugging the Konf
-    - Debugging Templates
-2. Common Errors
-3. Dust.js Documentation
+* TOC
+{:toc}
 
-# Debugging
+# Debugging 
 
 ## Tools
 
@@ -15,26 +16,26 @@ Debugging Mobify.js adaptations requires the use of a web inspection tool like
 Webkit Inspector or Firebug. You're likely well-acquainted with one of these, 
 but here are a few quick start tips if not.
 
-**Webkit Inspector**
+### Webkit Inspector
 
 The Webkit Inspector is a powerful web development tool that is built into the 
 Safari and Chrome browsers.
 
 To enable the inspector in Safari, open the Preferences pane, click Advanced, 
-then select "Show Develop menu in menu bar". Open the inspector by right 
-clicking on an element in a webpage and then selecting "Inspect Element".
+then select _"Show Develop menu in menu bar"_. Open the inspector by right-clicking
+on an element in a web page and then selecting _"Inspect Element"_.
 
 In Chrome, open the inspector by right clicking on an element in a webpage and 
-then selecting "Inspect Element".
+then selecting _"Inspect Element"_.
 
-**Firebug**
+### Firebug
 
 Firebug provides similiar behaviour to the WebKit Inspector in the Firefox 
-browser. [Install the Firebug plugin.](http://getfirebug.com/). Once installed, 
-in the browser's "View" menu, click the "Firebug" option at the bottom to 
+browser. [Install the Firebug plugin](http://getfirebug.com/). Once installed, 
+in the browser's _"View"_ menu, click the _"Firebug"_ option at the bottom to 
 initialize.
 
-For more on getting started with Firebug, watch this [helpful 
+For more on getting started with Firebug, watch [this helpful 
 video](http://www.youtube.com/watch?v=2xxfvuZFHsM).
 
 ## Debugging the Konf
@@ -44,19 +45,22 @@ springing up as you develop. The best way to debug the konf is with the Webkit
 Inspector or the Firebug extension.
 
 In development mode, the result of the evaluated konf, the context, is logged to
-the JavaScript console. Look for a the item 'All Extracted Data', which can be 
-expanded to show what values were assigned to what keys. **Note**: Extracted 
-Data is only available in development mode, which can be activated by browsing 
-your site through http://preview.mobify.com/
+the JavaScript console. Look for a the item _'All Extracted Data'_, which can be 
+expanded to show what values were assigned to what keys.
+
+**Note**: Extracted 
+Data is only available in development mode, which can be activated by browsing to
+your site through <https://preview.mobify.com/>.
 
 If you are stumped, try adding a `debugger;` statement into your konf. This will 
 cause the inspector's debugger to pause as the konf is evaluated:
-
-    'content': function() {
-        debugger;
-        return $('.content');
-    }
-
+{% highlight javascript %}
+'content': function() {
+    debugger;
+    // The debugger will pause here.
+    return $('.content');
+}
+{% endhighlight %}
 You can then use the inspector to step through the execution of your konf.
 
 ## Debugging Templates (Viewing source, inspecting rendered DOM)
@@ -73,27 +77,29 @@ Errors Mobify.js encounters during execution are logged to the JavaScript
 console. You can view these errors using Webkit Inspector or Firebug. If things 
 don't appear to be working, we suggest starting there!
 
-* **Page is blank, doesn't render at all**
+## Page is blank, doesn't render at all
 
-    Usually this will be accompanied by the error message: 
+Usually this will be accompanied by the error message: 
 
-        Uncaught SyntaxError: Unexpected string.
+    Uncaught SyntaxError: Unexpected string.
 
-    SOLUTION: Ensure that you have a comma after every key within your konf, ie.
+**Solution:** Ensure that you have a comma after every key within your konf, ie.
 
-        'header': {
-            ...
-        },
-        'content': {
+{% highlight javascript %}
+    'header': {
+        ...
+    }, // Commas between each key are required
+    'content': {
 
-        },
+    },
+{% endhighlight %}
 
-* **{some-key} displayed on the page**
+## "{some-key}" displayed on the page
 
-    When a variable is rendered to the page instead of parsed with data from 
-    your konf, this likely means you have used an illegal character in the key.
+When a variable is rendered to the page instead of parsed with data from 
+your konf, this likely means you have used an illegal character in the key.
 
-    SOLUTION: Don't use illegal characters in keys. This includes almost all 
+**Solution:** Don't use illegal characters in keys. This includes almost all 
     non-alphanumeric characters, ie. dashes (-), periods (.), commas (,), plus 
     signs (+), etc.
 

--- a/docs/appendix.md
+++ b/docs/appendix.md
@@ -1,9 +1,9 @@
 # Appendix
 
 1. Debugging
-	- Tools
-	- Debugging the Konf
-	- Debugging Templates
+    - Tools
+    - Debugging the Konf
+    - Debugging Templates
 2. Common Errors
 3. Dust.js Documentation
 
@@ -11,29 +11,46 @@
 
 ## Tools
 
-Debugging Mobify.js adaptations requires the use of a web inspection tool like Webkit Inspector or Firebug. You're likely well-acquainted with one of these, but here are a few quick start tips if not.
+Debugging Mobify.js adaptations requires the use of a web inspection tool like 
+Webkit Inspector or Firebug. You're likely well-acquainted with one of these, 
+but here are a few quick start tips if not.
 
 **Webkit Inspector**
 
-The Webkit Inspector is a powerful web development tool that is built into the Safari and Chrome browsers.
+The Webkit Inspector is a powerful web development tool that is built into the 
+Safari and Chrome browsers.
 
-To enable the inspector in Safari, open the Preferences pane, click Advanced, then select "Show Develop menu in menu bar". Open the inspector by right clicking on an element in a webpage and then selecting "Inspect Element".
+To enable the inspector in Safari, open the Preferences pane, click Advanced, 
+then select "Show Develop menu in menu bar". Open the inspector by right 
+clicking on an element in a webpage and then selecting "Inspect Element".
 
-In Chrome, open the inspector by right clicking on an element in a webpage and then selecting "Inspect Element".
+In Chrome, open the inspector by right clicking on an element in a webpage and 
+then selecting "Inspect Element".
 
 **Firebug**
 
-Firebug provides similiar behaviour to the WebKit Inspector in the Firefox browser. [Install the Firebug plugin.](http://getfirebug.com/). Once installed, in the browser's "View" menu, click the "Firebug" option at the bottom to initialize.
+Firebug provides similiar behaviour to the WebKit Inspector in the Firefox 
+browser. [Install the Firebug plugin.](http://getfirebug.com/). Once installed, 
+in the browser's "View" menu, click the "Firebug" option at the bottom to 
+initialize.
 
-For more on getting started with Firebug, watch this [helpful video](http://www.youtube.com/watch?v=2xxfvuZFHsM).
+For more on getting started with Firebug, watch this [helpful 
+video](http://www.youtube.com/watch?v=2xxfvuZFHsM).
 
 ## Debugging the Konf
 
-The konf is written in JavaScript and you will often find syntax or logic errors springing up as you develop. The best way to debug the konf is with the Webkit Inspector or the Firebug extension.
+The konf is written in JavaScript and you will often find syntax or logic errors 
+springing up as you develop. The best way to debug the konf is with the Webkit 
+Inspector or the Firebug extension.
 
-In development mode, the result of the evaluated konf, the context, is logged to the JavaScript console. Look for a the item 'All Extracted Data', which can be expanded to show what values were assigned to what keys. **Note**: Extracted Data is only available in development mode, which can be activated by browsing your site through http://preview.mobify.com/
+In development mode, the result of the evaluated konf, the context, is logged to
+the JavaScript console. Look for a the item 'All Extracted Data', which can be 
+expanded to show what values were assigned to what keys. **Note**: Extracted 
+Data is only available in development mode, which can be activated by browsing 
+your site through http://preview.mobify.com/
 
-If you are stumped, try adding a `debugger;` statement into your konf. This will cause the inspector's debugger to pause as the konf is evaluated:
+If you are stumped, try adding a `debugger;` statement into your konf. This will 
+cause the inspector's debugger to pause as the konf is evaluated:
 
     'content': function() {
         debugger;
@@ -44,15 +61,23 @@ You can then use the inspector to step through the execution of your konf.
 
 ## Debugging Templates (Viewing source, inspecting rendered DOM)
 
-Mobify.js adaptations are evaluated against the source DOM. "View Source" shows the source DOM, not the result of the adaptation. In situations where you need to view the rendered DOM, use Firebug or the WebKit inspector. The DOM tab (labelled 'HTML' or 'Elements') displays a DOM tree that shows the adaptated DOM. Browse this tree to see the full result of the adaptation.
+Mobify.js adaptations are evaluated against the source DOM. "View Source" shows
+ the source DOM, not the result of the adaptation. In situations where you need 
+ to view the rendered DOM, use Firebug or the WebKit inspector. The DOM tab 
+ (labelled 'HTML' or 'Elements') displays a DOM tree that shows the adaptated 
+ DOM. Browse this tree to see the full result of the adaptation.
 
 # Common Issues
 
-Errors Mobify.js encounters during execution are logged to the JavaScript console. You can view these errors using Webkit Inspector or Firebug. If things don't appear to be working, we suggest starting there!
+Errors Mobify.js encounters during execution are logged to the JavaScript 
+console. You can view these errors using Webkit Inspector or Firebug. If things 
+don't appear to be working, we suggest starting there!
 
 * **Page is blank, doesn't render at all**
 
-    Usually this will be accompanied by the error message: "Uncaught SyntaxError: Unexpected string".
+    Usually this will be accompanied by the error message: 
+
+        Uncaught SyntaxError: Unexpected string.
 
     SOLUTION: Ensure that you have a comma after every key within your konf, ie.
 
@@ -65,12 +90,19 @@ Errors Mobify.js encounters during execution are logged to the JavaScript consol
 
 * **{some-key} displayed on the page**
 
-    When a variable is rendered to the page instead of parsed with data from your konf, this likely means you have used an illegal character in the key.
+    When a variable is rendered to the page instead of parsed with data from 
+    your konf, this likely means you have used an illegal character in the key.
 
-    SOLUTION: Don't use illegal characters in keys. This includes almost all non-alphanumeric characters, ie. dashes (-), periods (.), commas (,), plus signs (+), etc.
+    SOLUTION: Don't use illegal characters in keys. This includes almost all 
+    non-alphanumeric characters, ie. dashes (-), periods (.), commas (,), plus 
+    signs (+), etc.
 
 # Dust.js Documentation
 
-Mobify.js templates extend the Dust.js JavaScript templating language. For more advanced examples of the syntax, you might find it helpful to browse the [Dust documentation](http://akdubya.github.com/dustjs/).
+Mobify.js templates extend the Dust.js JavaScript templating language. For more 
+advanced examples of the syntax, you might find it helpful to browse the 
+[Dust documentation](http://akdubya.github.com/dustjs/).
 
-You will likely find there to be differences in terminology and syntax, so we suggest making sure you're knowledgable about Mobify.js templates before doing so.
+You will likely find there to be differences in terminology and syntax, so we 
+suggest making sure you're knowledgable about Mobify.js templates before doing 
+so.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,3 +1,14 @@
+---
+layout: doc
+title: Getting Started
+---
+
+Getting Started
+===============
+
+ * TOC
+ {:toc}
+
 Mobify.js adapts existing websites for mobile devices using their source HTML.
 The Mobify.js tag loads a bundle, which contains the Konf, templates and other
 resources. Using the 'Konf', we select and adapt HTML elements from the
@@ -5,29 +16,13 @@ original site content, then we render the adapted content using 'templates' to
 produce a new page for the browser.
 
 This guide will help you understand the contents of your project.
-
   
 You will learn how to:
 
-  * Use the Konf to select content from your site's source DOM.
-  * Output your adaptation to the browser using templates.
+ * Use the Konf to select content from your site's source DOM.
+ * Output your adaptation to the browser using templates.
 
-* * *
-
-In this guide:
-
-  1. Tutorial requirements
-  2. Previewing your work
-  3. Introducing the Konf
-  4. Introducing Templates
-  5. Creating a template for a different page of your site
-  6. Pushing a bundle up to Cloud
-  7. Publishing to Production
-
-
-* * *
-
-##  Tutorial requirements
+## Tutorial requirements
 
 **We assume you have have created a project and installed the mobify client.**
 
@@ -39,19 +34,26 @@ The Mobify Client allows you to preview changes you make to your local bundle.
 
 Do the following:
 
-  1. In a Terminal window in your project's directory, run:&nbsp_place_holder;`mobify preview.`&nbsp_place_holder;This command will be generate a bundle locally, on the fly, as you edit your files. You'll want to keep this window open to see debugging information as you work on your mobified site.
-  2. On http://cloud.mobify.com, navigate to your project, then click 'Preview' in the left-hand navigation. If preview is running, then 'localhost' will be selected by default.
+ 1. In a *Terminal* window in your project's directory, run:  `mobify preview`
+ 
+    This command compile your bundle locally, on the fly, as you edit your files. 
+    You'll want to keep this window open to see debugging information as you
+    work on your mobified site.
+
+  2. On <http://cloud.mobify.com>, navigate to your project, then click _'Preview'_ 
+     in the left-hand navigation. If preview is running, then _'localhost'_
+     will be selected by default.
 
 Each time you make a change to your files, you can hit the refresh button to
 see your changes. If you ever refresh, and suddenly you are viewing your
-desktop site, then try opening up the javascript console.
+desktop site, try opening up the javascript console.
 
 ##  What is a 'Konf'?
 
 The Konf is JavaScript that selects and adapts content from a site's source
 DOM. The selections made in the Konf are used as the context to render a
 template, producing the mobified page. The Konf file is required in any Mobify
-project, and by default lives at '**src/mobify.konf**'.
+project, and by default lives at **'src/mobify.konf'**.
 
 ##  Templates
 
@@ -61,17 +63,24 @@ and give you control over the output of your mobified page.
 
 By default, a project starts with four templates:
 
-  * **base.tmpl**: An example base template which&nbsp_place_holder;contains the HTML skeleton of your project, which contains a default css file, viewport, and set of sane block placeholders which are ment to be overridden in other templates (such as home.tmpl).
-  * **home.tmpl**: An example template for use with a home page
-  * **_header.tmpl**: A template which gets included immediately below the opening body tag in base.tmpl
-  * **_footer.tmpl**:&nbsp_place_holder;A template which gets included immediately above the closing body tag in base.tmpl
+ - **base.tmpl**: An example base template which contains the HTML skeleton
+   of your project, which contains a default css file, viewport, and set of
+   sane block placeholders which are ment to be overridden in other 
+   templates (such as home.tmpl).
+
+ - **home.tmpl**: An example template for use with a home page
+
+ - **\_header.tmpl**: A template which gets included immediately below the 
+   opening body tag in base.tmpl
+
+ - **\_footer.tmpl**: A template which gets included immediately above the closing
+   body tag in base.tmpl
 
 
 ##  Creating a template for a different page of your site
 
 Up to this point, we have a base template, a home template, a header template,
 and a footer template. To mobify more pages, you will need more templates!
-
   
 We'll adapt a hypothetical 'About' page for the purposes of this tutorial (If
 you don't have an 'About' page, or want to try mobifying a different set of
@@ -80,51 +89,50 @@ mobify)
 
 You will want to uncomment the following block in your mobify.konf file:
 
-    
-    
-    	/*{
+{% highlight javascript %}    	/*{
             '!templateName': 'about',
             '!phonenumber' : function() {
                  return $('.selector_for_phone_number');
-    	},
+    	    },
             '!blurb': function() {
                  return $('.selector_for_blurb');
             }
         }*/
+{% endhighlight %}
     
 
-Make sure you change **.selector_for_phone_number** and
-**.selector_for_blurb** to something that is unique to the page you're
+Make sure you change `.selector_for_phone_number` and
+`.selector_for_blurb` to something that is unique to the page you're
 mobifying.
 
   
 You may have noticed that this object you uncommented is an argument that gets
-passed into context.choose(). In order to determine what template to use, the
+passed into `context.choose()`. In order to determine what template to use, the
 Mobify frameworks determines which template to render by asking you to
 describe what DOM elements must match for a particular template to render.
 This DOM description is also used as the context which is used when rendering
 templates - so you can see in the example above, you have a
-"!phonenumber" and "!blurb" key, and if those keys match the DOM of the page,
-then the "about" template will be rendered. These keys are then accessible as
+`!phonenumber` and `!blurb` key, and if those keys match the DOM of the page,
+then the **"about"** template will be rendered. These keys are then accessible as
 data within the template (so, for example, you could access the phone number
-like this: {content.phonenumber} ). Keys with ! prefixed are
+like this: `{content.phonenumber}` ). Keys with `!` prefixed are
 _required_ in order for the template to render. Sometimes,
 you may want to extract data from a page, but it isn't something that is
 required in order to render the page. In that case, you simply add a key
-without the ! prefix.
+without the `!` prefix.
 
 Now, you need to create a corresponding template for the 'About' page. Here is
 an example of what it may look like.
 
-### about.tmpl
-    
-    {>base/}
+####  about.tmpl
+{% highlight html+django %}     {>base/}
     
     {<content}
         <h1>About page</h1>
         <h3>My phone number: "{content.phonenumber}"</h3>
         <p>{content.blurb}</p>
     {/content}
+{% endhighlight %}
 
 Simply navigate to the about page (make sure `mobify preview` is still
 running!, and you will see your About page rendered through Mobify.js. If for

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -20,7 +20,9 @@ In this guide:
   2. Previewing your work
   3. Introducing the Konf
   4. Introducing Templates
-  5. Creating a template for a different page of your site:0
+  5. Creating a template for a different page of your site
+  6. Pushing a bundle up to Cloud
+  7. Publishing to Production
 
 
 * * *
@@ -101,12 +103,12 @@ passed into context.choose(). In order to determine what template to use, the
 Mobify frameworks determines which template to render by asking you to
 describe what DOM elements must match for a particular template to render.
 This DOM description is also used as the context which is used when rendering
-templates - &nbsp_place_holder;so you can see in the example above, you have a
+templates - so you can see in the example above, you have a
 "!phonenumber" and "!blurb" key, and if those keys match the DOM of the page,
 then the "about" template will be rendered. These keys are then accessible as
 data within the template (so, for example, you could access the phone number
 like this: {content.phonenumber} ). Keys with ! prefixed are
-_required_&nbsp_place_holder;in order for the template to render. Sometimes,
+_required_ in order for the template to render. Sometimes,
 you may want to extract data from a page, but it isn't something that is
 required in order to render the page. In that case, you simply add a key
 without the ! prefix.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,131 @@
+Mobify.js adapts existing websites for mobile devices using their source HTML.
+The Mobify.js tag loads a bundle, which contains the Konf, templates and other
+resources. Using the 'Konf', we select and adapt HTML elements from the
+original site content, then we render the adapted content using 'templates' to
+produce a new page for the browser.
+
+This guide will help you understand the contents of your project.
+
+  
+You will learn how to:
+
+  * Use the Konf to select content from your site's source DOM.
+  * Output your adaptation to the browser using templates.
+
+* * *
+
+In this guide:
+
+  1. Tutorial requirements
+  2. Previewing your work
+  3. Introducing the Konf
+  4. Introducing Templates
+  5. Creating a template for a different page of your site
+
+* * *
+
+##  Tutorial requirements
+
+**We assume you have have created a project and installed the mobify client.**
+
+**[If you haven't, go do it now!](http://portal.mobify.com/projects/new/)**
+
+##  Previewing your work
+
+The Mobify Client allows you to preview changes you make to your local bundle.
+
+Do the following:
+
+  1. In a Terminal window in your project's directory, run:&nbsp_place_holder;`mobify preview.`&nbsp_place_holder;This command will be generate a bundle locally, on the fly, as you edit your files. You'll want to keep this window open to see debugging information as you work on your mobified site.
+
+  2. On http://cloud.mobify.com, navigate to your project, then click 'Preview' in the left-hand navigation. If preview is running, then 'localhost' will be selected by default.
+
+Each time you make a change to your files, you can hit the refresh button to
+see your changes. If you ever refresh, and suddenly you are viewing your
+desktop site, then try opening up the javascript console.
+
+##  What is a 'Konf'?
+
+The Konf is JavaScript that selects and adapts content from a site's source
+DOM. The selections made in the Konf are used as the context to render a
+template, producing the mobified page. The Konf file is required in any Mobify
+project, and by default lives at '**src/mobify.konf**'.
+
+##  Templates
+
+A template is a text file that contains variables which are replaced when the
+template is rendered. In Mobify.js, templates are used to remix the source DOM
+and give you control over the output of your mobified page.
+
+By default, a project starts with four templates:
+
+  * **base.tmpl**: An example base template which&nbsp_place_holder;contains the HTML skeleton of your project, which contains a default css file, viewport, and set of sane block placeholders which are ment to be overridden in other templates (such as home.tmpl).
+  * **home.tmpl**: An example template for use with a home page
+  * **_header.tmpl**: A template which gets included immediately below the opening body tag in base.tmpl
+  * **_footer.tmpl**:&nbsp_place_holder;A template which gets included immediately above the closing body tag in base.tmpl
+
+
+##  Creating a template for a different page of your site
+
+Up to this point, we have a base template, a home template, a header template,
+and a footer template. To mobify more pages, you will need more templates!
+
+  
+We'll adapt a hypothetical 'About' page for the purposes of this tutorial (If
+you don't have an 'About' page, or want to try mobifying a different set of
+pages, you can follow along, substituting 'About' with the page you want to
+mobify)
+
+You will want to uncomment the following block in your mobify.konf file:
+
+    
+    
+    	/*{
+            '!templateName': 'about',
+            '!phonenumber' : function() {
+                 return $('.selector_for_phone_number');
+    	},
+            '!blurb': function() {
+                 return $('.selector_for_blurb');
+            }
+        }*/
+    
+
+Make sure you change **.selector_for_phone_number** and
+**.selector_for_blurb** to something that is unique to the page you're
+mobifying.
+
+  
+You may have noticed that this object you uncommented is an argument that gets
+passed into context.choose(). In order to determine what template to use, the
+Mobify frameworks determines which template to render by asking you to
+describe what DOM elements must match for a particular template to render.
+This DOM description is also used as the context which is used when rendering
+templates - &nbsp_place_holder;so you can see in the example above, you have a
+"!phonenumber" and "!blurb" key, and if those keys match the DOM of the page,
+then the "about" template will be rendered. These keys are then accessible as
+data within the template (so, for example, you could access the phone number
+like this: {content.phonenumber} ). Keys with ! prefixed are
+_required_&nbsp_place_holder;in order for the template to render. Sometimes,
+you may want to extract data from a page, but it isn't something that is
+required in order to render the page. In that case, you simply add a key
+without the ! prefix.
+
+Now, you need to create a corresponding template for the 'About' page. Here is
+an example of what it may look like.
+
+####  about.tmpl
+    
+    {>base/}
+    
+    {<content}
+        <h1>About page</h1>
+        <h3>My phone number: "{content.phonenumber}"</h3>
+        <p>{content.blurb}</p>
+    {/content}
+
+Simply navigate to the about page (make sure `mobify preview` is still
+running!, and you will see your About page rendered through Mobify.js. If for
+some reason you see your desktop site, open up the javascript console to see
+any potential errors.
+

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -20,7 +20,8 @@ In this guide:
   2. Previewing your work
   3. Introducing the Konf
   4. Introducing Templates
-  5. Creating a template for a different page of your site
+  5. Creating a template for a different page of your site:0
+
 
 * * *
 
@@ -37,7 +38,6 @@ The Mobify Client allows you to preview changes you make to your local bundle.
 Do the following:
 
   1. In a Terminal window in your project's directory, run:&nbsp_place_holder;`mobify preview.`&nbsp_place_holder;This command will be generate a bundle locally, on the fly, as you edit your files. You'll want to keep this window open to see debugging information as you work on your mobified site.
-
   2. On http://cloud.mobify.com, navigate to your project, then click 'Preview' in the left-hand navigation. If preview is running, then 'localhost' will be selected by default.
 
 Each time you make a change to your files, you can hit the refresh button to
@@ -114,7 +114,7 @@ without the ! prefix.
 Now, you need to create a corresponding template for the 'About' page. Here is
 an example of what it may look like.
 
-####  about.tmpl
+### about.tmpl
     
     {>base/}
     
@@ -129,3 +129,25 @@ running!, and you will see your About page rendered through Mobify.js. If for
 some reason you see your desktop site, open up the javascript console to see
 any potential errors.
 
+## Pushing a bundle up to Cloud
+
+Now that your site is looking decent, you might want to start thinking about 
+pushing up bundles to the Cloud in order to view them on your mobile device, if you
+have a bundle that you think you might want to publish to production.
+
+In order to do that, you can simply go to the root directory of your project folder
+and execute this command:
+
+    mobify push --message "Initial Push"
+    
+After you've pushed, go back to the Preview page and refresh, and you will see the bundle
+you just pushed in the "Available Bundles" dropdown. Once you select your bundle,
+you'll notice that you can email this link to yourself or someone else in order to 
+see it on your mobile phone through the interface on Cloud.
+
+## Publishing to Production
+
+Once you've gone through and modified your mobile site to your liking, you can publish your
+bundle to production. Just click on the "Publishing" page on the left hand side, and you'll
+see a list of bundles that you've pushed up to cloud. From there, you can select the one
+you want to publish!

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,19 +1,48 @@
+---
+layout: doc
+title: Glossary
+---
+
 # Mobify Glossary
 
-* ATTRIBUTES - Additional data values which may be returned along with variables. Each attribute maps to a specific member key within the parent key in the konf.
+* Toc
+{:toc}
 
-* CONTEXT - Within the konf, you select data and objects from your source DOM. When the konf is evaluated, those selections are returned for use in a mobile template. A view context is a variable name/value mapping that is passed on to the template. [Learn more about context] https://support.mobify.com/customer/portal/articles/511697-template-reference
+## Terms & Definitions
 
-* KEYS - Labels that uniquely reference each selection you make within the konf file. Also serve as variable/attribute names within your templates.
+### Attributes
 
-* KONF - A JavaScript file that enables content selection from a source DOM.
+> Additional data values which may be returned along with variables.
+> Each attribute maps to a specific member key within the parent key in the konf.
 
-* RENDERED DOM - The mobile site's post-adaptation DOM, the output of Mobify.js.
+### Context
 
-* SELECTIONS - Data and objects returned by a jQuery-like (Zepto) selector within the konf file.
+> Within the konf, you select data and objects from your source DOM. When the konf is evaluated, those selections are returned for use in a mobile template. A view context is a variable name/value mapping that is passed on to the template. [Learn more about context](https://support.mobify.com/customer/portal/articles/511697-template-reference)
 
-* SOURCE DOM - Your site's original DOM, ie. the DOM tree you'd see if you viewed source before Mobifying.
+### Keys
 
-* TEMPLATES - A template is a text file that contains regular HTML markup, plus variables that are replaced when the template is rendered.
+> Labels that uniquely reference each selection you make within the konf file. Also serve as variable/attribute names within your templates.
 
-* VARIABLES - Context mapped data returned to your template from the konf selections. Each variable maps to a key in the context.
+### Konf
+
+> A JavaScript file that enables content selection from a source DOM.
+
+### Rendered DOM
+
+> The mobile site's post-adaptation DOM, the output of Mobify.js.
+
+### Selections
+
+> Data and objects returned by a jQuery-like (Zepto) selector within the konf file.
+
+### Source DOM 
+
+> Your site's original DOM, ie. the DOM tree you'd see if you viewed source before Mobifying.
+
+### Templates
+
+> A template is a text file that contains regular HTML markup, plus variables that are replaced when the template is rendered.
+
+### Variables
+
+> Context mapped data returned to your template from the konf selections. Each variable maps to a key in the context.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,0 +1,19 @@
+# Mobify Glossary
+
+* ATTRIBUTES - Additional data values which may be returned along with variables. Each attribute maps to a specific member key within the parent key in the konf.
+
+* CONTEXT - Within the konf, you select data and objects from your source DOM. When the konf is evaluated, those selections are returned for use in a mobile template. A view context is a variable name/value mapping that is passed on to the template. [Learn more about context] https://support.mobify.com/customer/portal/articles/511697-template-reference
+
+* KEYS - Labels that uniquely reference each selection you make within the konf file. Also serve as variable/attribute names within your templates.
+
+* KONF - A JavaScript file that enables content selection from a source DOM.
+
+* RENDERED DOM - The mobile site's post-adaptation DOM, the output of Mobify.js.
+
+* SELECTIONS - Data and objects returned by a jQuery-like (Zepto) selector within the konf file.
+
+* SOURCE DOM - Your site's original DOM, ie. the DOM tree you'd see if you viewed source before Mobifying.
+
+* TEMPLATES - A template is a text file that contains regular HTML markup, plus variables that are replaced when the template is rendered.
+
+* VARIABLES - Context mapped data returned to your template from the konf selections. Each variable maps to a key in the context.

--- a/docs/konf-reference.md
+++ b/docs/konf-reference.md
@@ -1,3 +1,8 @@
+---
+layout: doc
+title: Konf Reference 
+---
+
 # Konf Reference
 
 1. Using Konf

--- a/docs/konf-reference.md
+++ b/docs/konf-reference.md
@@ -1,0 +1,238 @@
+# Konf Reference
+
+1. Using Konf
+2. OUTPUTHTML
+3. context.data
+4. context.tmpl
+5. context.choose
+6. Reserved Keys
+7. Best Practices
+
+
+## 1\. Using Konf
+
+The Mobify.js konf selects elements from the source DOM to be rendered on the mobile site. To make selection easy, mobify.js includes Zepto.js, a minimalist JavaScript selector library optimized for mobile with a jQuery-compatible API. 
+
+A simple selector to assign the site's logo to a key might look like this:
+
+    'logo': function() {
+        return $('.identity img')
+    },
+
+This key will apply to every page where the selector evaluates to true. Note that the corresponding page template needs to include a variable that references the key for it to render.
+
+The konf is also used to determine which templates will render for each page by evaluating jQuery-like selectors against the current page:
+
+    return context.choose({
+        'templateName': 'homePage',
+        '!products': function() {
+            return $('#product-carousel')
+        }
+    }, {
+        'templateName': 'productPage',
+        '!class': function() {
+            return $('.product-list')
+        },
+    }
+
+The first selector will search the current page for an element with the id of `product-carousel`. If it finds it, the required key `products` evaluates to true and the page will immediately be rendered with _homePage.tmpl_. If not, then (and only then) the second selector is evaluated and if an element with a `product-list` class is found, the page will instead be rendered with _productPage.tmpl_. See below for more on how `context.choose` works.
+
+Only templates with conditions that evaluate to true will render, and when multiple templates could potentially apply only the first matching template will be chosen for the page.
+
+Template mapping is accomplished indirectly through DOM matching, note that there is no direct way to select a template for a specific page on your site. 
+
+For example, instead of simply defining templates this way:
+
+    'homePage': 'home.tmpl'
+
+You would instead find unique selectors that only apply on the page you want to render a template, then assign that template using `context.choose`:
+
+    return context.choose({
+        'templateName': 'homePage',
+        '!class': function() {
+            return $('body.home-page')
+        },
+    }        
+
+Single selectors as above are easy enough, but we recommend instead describing (via selections) the ideal DOM including all elements on the page that you will adapt for your mobile site. Then assign a template to that desired DOM:
+
+    return context.choose({
+        'templateName': 'homePage',
+        '!productCarousel': function() {
+            return $('.product-carousel')
+        },
+        '!saleItems': function() {
+            return $('.sale-items')
+        },
+        '!customerService': function() {
+            return $('.customer-service')
+        }
+    },
+
+Why do it this more verbose way? We believe the most robust method of selecting content for your mobile site is by describing the overall makeup of the page rather than having your selectors rely too heavily on any one specific class or id.
+
+We all know that websites change. When your source DOM becomes even superficially different from when you developed your mobile site, there's a chance that your once-valid selections will stop matching and your mobile users will experience blank pages. 
+
+With the above example, what happens when the sale ends? Sales items removed from the DOM mean the required `saleItems` key no longer returns a valid result. Mobify.js has a choice in this situation - it could either stop rendering required items, or fall back to the desktop site. Since `productCarousel` and `customerService` are also required, they would not render at all if we were to choose the former approach.
+
+On the chance that `productCarousel`, `customerService` or any other required selections make up the bulk of your home page content, we think it's far better to fall back to the desktop site. This approach will continue to provide your users with content instead of serving them a mostly empty mobile site.
+
+
+## 2\. `OUTPUTHTML`
+    
+`OUTPUTHTML` is a special key of the konf object. Any string it returns will be rendered immediately as the output of the page. For this reason, it should **always** be declared as the very last key of the konf object:
+
+    'OUTPUTHTML': function(context) {
+        return '<html><body><h1>HELLO MOBIFY!</h1></body></html>'
+    }
+
+
+## 3\. `context.data(key)`
+
+Returns the value of an previously-assigned key in the konf object. Since the konf object is evaluated from top to bottom, it is possible to access previous keys in later assignments. For example you may wish to reuse a selection made for the `content` within `footer`. 
+
+    'content': function() {
+        return $('.page-content')
+    },
+    'footer': function(context) {
+        return context.data('content');
+    }
+
+This passes to `footer` the value of the `content` key, which is in turn the evaluated return of the selector `$('.content')`.
+
+**Variable Resolution**
+
+`context.data(key)` returns the matching key at the closest level. If the key is not found at the current level, it ascends to the parent level and tries again. 
+
+
+## 4\. `context.tmpl(template)`
+
+Returns the specified .tmpl file template, rendered against the evaluated konf object. 
+
+    'OUTPUTHTML': function(context) {
+        return context.tmpl('home')
+    }
+
+This renders the _home.tmpl_ via the `OUTPUTHTML` key. By default, all _.tmpl_ files in the project's _tmpl/_ folder are available to the `context.tmpl` function.
+
+A common pattern is to conditionally assign template names to a specific key in the konf object, access the key with `context.data`, then use `context.tmpl` to render the selected template using the `OUTPUTHTML` key:
+
+    'template': 'home',
+    'OUTPUTHTML': function(context) {
+        var template = context.data('template')
+        return context.tmpl(template)
+    }
+
+This assigns a value of `home` to the key later referenced by `context.data`. The returned value is passed to _context.tmpl_ as a template name, which is returned to `OUTPUTHTML` for rendering.
+
+
+## 5\. `context.choose(obj1[, obj2[, ...]])`
+
+Accepts anonymous JSON objects as parameters and returns the first object that matches. An object is considered to match if all internal keys prefixed with `!` evaluate to a truthy value:
+
+    'content': function(context) {
+        return context.choose({
+            '!home': function(context) {
+                return $('#product-carousel')
+            }
+        }, {
+            '!products': function(context) {
+                return $('.product-listing')
+            }
+        })
+    }
+
+In this example, the first object would match if the function assigned to the key `!home` evaluated to a truthy value. If it did not, the first object would not match and the next object would be tested. If both match, only the first is returned.
+
+An object with no required selections always matches:
+
+    'content': function(context) {
+        return context.choose({
+            'home': function(context) {
+                return $('#product-carousel')
+            }
+        })
+    }
+
+If no matching objects are found `context.choose` returns undefined. Multiple keys may be prefixed with `!` to create `and` conditions: 
+
+    'home': function(context) {
+        return context.choose({
+            'templateName': 'homePage',
+            '!productCarousel': function() {
+                return $('#product-carousel')
+            },
+            '!saleItems': function() {
+                return $('.sale-items')
+            }
+        },
+    }
+
+So in this case if both selectors evaluate to true within the current page, the home key will be assigned the value of `templateName`, otherwise it remains unassigned.
+
+A common pattern in a konf object is to use `context.choose` to select template specific content and set a key which will be used as the template name:
+
+    'content': function(context) {
+        return context.choose({
+            'template': 'home',
+            '!home': function(context) {
+                return $('#product-carousel')
+            }
+        }, {
+            'template': 'saleItems',
+            '!item': function(context) {
+                return $('.sale-items')
+            }
+        })
+    },
+    'OUTPUTHTML': function(context) {
+        var template = context.data('content.template')
+        if (template) {
+            return context.tmpl(template)
+        }
+    }
+
+
+**Truthiness Of `!`**
+
+`context.choose` considers a value to be truthy if it matches one of the following conditions:
+
+    obj.length && obj.length > 0
+    obj == true
+
+If none of these conditions are true then a value is considered falsey.
+
+Important: changing the DOM within required selections might adversely affect evaluation further down the konf. We recommend avoiding DOM manipulation on required selections in the konf.
+
+
+## 6\. Reserved Keys
+
+Your konf object extends a default konf object containing the following reserved keys:
+
+`$html`: Reference to the source DOM element
+`$head`: Reference to the source DOM element
+`$head`: Reference to the source DOM element
+`buildDate`: The date this _mobify.js_ file was built
+`config.configDir`: Path to the folder from where _mobify.js_ loaded
+`config.configFile`: Path to _mobify.js_
+`config.HD`: A boolean flag that will be true if this device has a high density display 
+`config.isDebug`: A boolean flag that will be true if mobify.js is running in debug mode
+`config.orientation`: A string that will be "portrait" if the device is taller than it is wide, or "landscape" if it is wider than it is tall
+`config.os`: A string representing the detected operating system of the device
+`config.path`: A string representing the path from where the mobify.js file was loaded
+`config.started`: An internal flag used to record whether the page has been transformed
+`config.tagVersion`: Version of the Mobify tag used on this site
+`config.touch`: A boolean flag that will be true if touch events are supported, false otherwise
+`configName`: A property pulled from _project.json_ - most likely the unique identifier for your site
+`cssName`: A function returning the name of the css file to be applied
+`imageDir`: A function returning a path to where mobify adaptation specific image assets are kept
+`mobileViewport`: Contents of the meta viewport tag to be sent
+`siteConfig`: An object containing analytics configuration information
+`touchIcon`: The location of a file to be used as the bookmark icon for this website on iOS devices
+`unmobify`: An internal flag used to record whether the page has been unmobified
+
+## 7\. Best Practices
+
+* DO: Prefer the matching of more complete DOM outlines over single selectors when assigning templates to specific pages.
+
+* DO NOT: alter the source DOM in required selectors, as they are evaluated regardless of whether they are used as a context to evaluate templates.

--- a/docs/konf-reference.md
+++ b/docs/konf-reference.md
@@ -210,25 +210,45 @@ Important: changing the DOM within required selections might adversely affect ev
 Your konf object extends a default konf object containing the following reserved keys:
 
 `$html`: Reference to the source DOM element
+
 `$head`: Reference to the source DOM element
+
 `$head`: Reference to the source DOM element
+
 `buildDate`: The date this _mobify.js_ file was built
+
 `config.configDir`: Path to the folder from where _mobify.js_ loaded
+
 `config.configFile`: Path to _mobify.js_
+
 `config.HD`: A boolean flag that will be true if this device has a high density display 
+
 `config.isDebug`: A boolean flag that will be true if mobify.js is running in debug mode
+
 `config.orientation`: A string that will be "portrait" if the device is taller than it is wide, or "landscape" if it is wider than it is tall
+
 `config.os`: A string representing the detected operating system of the device
+
 `config.path`: A string representing the path from where the mobify.js file was loaded
+
 `config.started`: An internal flag used to record whether the page has been transformed
+
 `config.tagVersion`: Version of the Mobify tag used on this site
+
 `config.touch`: A boolean flag that will be true if touch events are supported, false otherwise
+
 `configName`: A property pulled from _project.json_ - most likely the unique identifier for your site
+
 `cssName`: A function returning the name of the css file to be applied
+
 `imageDir`: A function returning a path to where mobify adaptation specific image assets are kept
+
 `mobileViewport`: Contents of the meta viewport tag to be sent
+
 `siteConfig`: An object containing analytics configuration information
+
 `touchIcon`: The location of a file to be used as the bookmark icon for this website on iOS devices
+
 `unmobify`: An internal flag used to record whether the page has been unmobified
 
 ## 7\. Best Practices

--- a/docs/template-reference.md
+++ b/docs/template-reference.md
@@ -241,7 +241,7 @@ This would insert the output of the template _logo.tmpl_ into _foo.tmpl_.
 
 ## 7\. `{+bar} ... {/bar}` - Block Placeholders
 
-Blocks allow you to define snippets of template code that may be overridden by any templates that reference this template:
+Blocks allow you to define snippets of template code that may be overridden by other templates:
 
 *Adding an overridable block `header` to _foo.tmpl_:*
     {+header}Plain Old Default Header{/header}

--- a/docs/template-reference.md
+++ b/docs/template-reference.md
@@ -1,3 +1,8 @@
+---
+layout: doc
+title: Template Reference 
+---
+
 # Template Reference
 
 1. Understanding Context
@@ -10,7 +15,7 @@
 8. `{<bar}...{/bar}` - Block Overrides
 9. `{?foo}...{/foo}` - Conditional (existence)
 10. `{^foo}...{/foo}` - Conditional (non-existence)
-11. `{%script}...{/script}` - Inline Script Pragma
+11. `{ %script}...{/script}` - Inline Script Pragma
 12. `{! Comment !}` - Template Comments
 
 **Best Practices**
@@ -218,7 +223,7 @@ Partials, also known as template includes, allow you to compose a template made 
 
     {site.logo}
 
-*`Referencing a partial to include in your template _foo.tmpl_:*
+*Referencing a partial to include in your template _foo.tmpl_:*
 
     <div id="header">
         {>logo/}
@@ -295,16 +300,16 @@ Provide conditional output based on the non-existence of a variable.
     {/user}
 
 
-## 11\. {%script} ... {/script} - Inline Script Pragma
+## 11\. { %script} ... {/script} - Inline Script Pragma
 
-By default, templates collapse whitespace. This is a problem when templating elements where whitespace matters, like inline scripts featuring single-line comments. The `{%script}` pragma is provided to safely handle inline scripting in templates.
+By default, templates collapse whitespace. This is a problem when templating elements where whitespace matters, like inline scripts featuring single-line comments. The `{ %script}` pragma is provided to safely handle inline scripting in templates.
 
-    {%script}
+    { %script}
         // Show an alert dialog
         alert("Hello Mobify!")
     {/script}
 
-See [handling JavaScript] https://support.mobify.com/customer/portal/articles/513026-handling-javascript-with-mobify-js for more detail.
+See [handling JavaScript](https://support.mobify.com/customer/portal/articles/513026-handling-javascript-with-mobify-js) for more detail.
 
 
 ## 12\. `{! Comment !}` - Template Comments

--- a/docs/template-reference.md
+++ b/docs/template-reference.md
@@ -1,0 +1,363 @@
+# Template Reference
+
+1. Understanding Context
+2. `{foo}` - Variables
+3. `{foo|bar}` - Variable Filters
+4. `{#foo}...{/foo}` - Attributes
+5. `{#foo}...{.}...{/foo}` - Iteration
+6. `{>foo/}` - Includes
+7. `{+bar}...{/bar}` - Block Placeholders
+8. `{<bar}...{/bar}` - Block Overrides
+9. `{?foo}...{/foo}` - Conditional (existence)
+10. `{^foo}...{/foo}` - Conditional (non-existence)
+11. `{%script}...{/script}` - Inline Script Pragma
+12. `{! Comment !}` - Template Comments
+
+**Best Practices**
+
+- Template File Naming Conventions
+- Use a Base Template
+- Prefix Introduced Styling Attributes With `'x-'`
+
+
+
+## 1\. Understanding Context
+
+Templates are HTML documents containing variables meant to be filled in with data extracted from your konf. This data comes from the evaluated konf output, referred to as the _context_ for the template.
+
+Context can be thought of as a tree of all the keys that your konf has evaluated as being applicable to this particular template. 
+
+You can view the full tree within your browser's Javascript console (see our tools guide in the Appendix if you're not familiar with its use). Browse to the page you'd like to inspect, open the console and find 'All extracted data' -- expand it to view all evaluated keys. Any of these are available for use as variables within your template. You'll find many internal keys that Mobify generates during operation, see Reserved Keys for a list of these.
+
+Note that when we talk about changing levels of context below, we simply mean traversing the levels of this context tree. 
+
+
+## 2\. `{foo}` - Variables: Select & Render A Single Variable
+
+Use any jQuery-like (Zepto) selector to select elements from your source DOM within the konf file. Reference the selection as a variable from any template using the curly brace syntax:
+
+*Original HTML input:*
+
+     <form id="search">
+         <input type="submit" value="Send" />
+     </form>
+
+*Assign a selection to a key, in the konf:*
+
+     'search': function() {
+         return $("form#search"); 
+     },
+
+*Render the result of the `search` key selection in the konf as a variable within your template:*
+
+     <div class="search">
+         {search}
+     </div>
+
+*Output HTML:*
+
+     <div class="search">
+         <form id="search">
+             <input type="submit" value="Send" />
+         </form>
+     </div>
+
+**Variable Evaluation**
+
+Zepto collections are evaluated by iterating the objects in the collection and calling the JavaScript `outerHTML()` attribute on each of them. A single DOM Element will have `outerHTML()` called on it by default.
+
+Note that all strings are escaped by default, so use a filter (see filter reference below) if you'd like to output HTML.
+
+**Variable Resolution**
+
+Variables are first looked-up at the current level of the context. If 'variable' is not found at this level, the variable will be searched for at the next highest level of the context, and so forth until it is found, or the highest level of the context is reached. 
+
+
+## 3\. `{foo|bar}` - Variable Filters: Pass The Value `foo` Through Filter `bar`
+
+If you would like to change how a variables value is rendered, especially values produced from Zepto collections or a DOM element, you can use filters. Add a pipe symbol `|` and filter name inside the template tag:
+
+*Original HTML input:*
+
+    <h3 class="warning">
+        <img src="icon.png" class="icon"> Warning: your balance is low
+    </h3>
+
+*The original selection in the konf:*
+
+    'warning': function() {
+        return $(".warning"); 
+    },
+
+*Add a filter to the `warning` variable within your template:*
+
+    {warning|innerHTML|s}
+
+*Output HTML:*
+
+    <img src="icon.png" class="icon"> Warning: your balance is low
+
+You can apply multiple filters in a chain by appending another pipe symbol `|` and filter name inside the template tag. Note that filters are cumulative, and will apply each additional filter to the output of the previous one.
+
+**Available Filters**
+
+* `innerHTML` - render the `innerHTML()` of a Zepto collection or DOM element. Note: the output of this filter will be HTML escaped, chain with `s` to safely render as HTML.
+
+* `openTag` - output the literal opening tag of a DOM element. Note: the output of this filter will be HTML escaped, chain with `s` to safely render as HTML.
+
+* `closeTag` - output the literal closing tag of a DOM element. Note: the output of this filter will be HTML escaped, chain with `s` to safely render as HTML.
+
+* `s` - render HTML safe output, unescapes HTML escaped strings, such as values filtered through the `innerHTML` filter.
+
+
+
+## 4\. `{#foo} ... {/foo}` - Accessing Attributes Of, Or Descend Into The Variable `foo`
+
+You are able to access any variable and its attributes. To simply access an attribute, you can use the simpler '{variable.attribute}' syntax:
+
+*Original HTML input:*
+
+    <div class="site-header">
+        <h1>DemoCorp Inc.</h1>
+        <nav>
+            <ul>
+                <li><a href="/">Home</a></li>
+                <li><a href="/products/">Products</a></li>
+                <li><a href="/contact/">Contact</a></li>
+            </ul>
+        </nav>
+    </div>
+
+*Create a header variable with logo attribute in the konf:*
+
+    'header': {
+        'logo': function() {
+            return $('.site-header h1')
+        }
+    }
+
+*Access the `logo` attribute within your template:*
+
+    <div id="fixed-nav">
+        {header.logo}
+    </div>
+
+*Output HTML:*
+
+    <div id="fixed-nav">
+        <h1>DemoCorp Inc.</h1>
+    </div>            
+
+Note that you can also access the same attribute within your template by descending into the header block, which is valuable when you have attached multiple attributes to the same variable. The output HTML would be identical to the last example:
+
+    <div id="fixed-nav">
+        {#header}
+            {logo}
+        {/header}
+    </div>
+
+
+## 5\. `{#foo} ... {.} ... {/foo}` - Iterate The Variable `foo`
+
+When you make a selection within the konf that returns multiple objects, you can easily iterate through those objects in your template using the '.' attribute, which is simply a reference to the current iteration:
+
+*Original HTML input:*
+
+    <div class="site-header">
+        <h1>DemoCorp Inc.</h1>
+        <nav>
+            <ul>
+                <li><a href="/">Home</a></li>
+                <li><a href="/products/">Products</a></li>
+                <li><a href="/contact/">Contact</a></li>
+            </ul>
+        </nav>
+    </div>
+
+*Create a variable with attributes in the konf:*
+
+    'header': {
+        'logo': function() {
+            return $('.site-header h1')
+        },
+        'nav': function() {
+            return $('.site-header nav a')
+        }
+    }
+
+*Iterate the `header` variable to access `logo` and `nav` attributes, also iterate `nav`:*
+
+    <div id="fixed-nav">
+        {#header}
+            {logo}
+            <ul class="pull-right">
+                {#nav}
+                    <li>{.}</li>
+                {/nav}
+            </ul>
+        {/header}
+    </div>
+
+*Output HTML:*
+
+    <div id="fixed-nav">
+        <h1>DemoCorp Inc.</h1>
+        <ul class="pull-right">
+            <li><a href="/">Home</a></li>
+            <li><a href="/products/">Products</a></li>
+            <li><a href="/contact/">Contact</a></li>
+        </ul>
+    </div>            
+
+
+## 6\. `{>foo/}` - Include The Partial `foo` Inside The Current Template
+
+Partials, also known as template includes, allow you to compose a template made of other templates:
+
+*Contents of partial `logo`:*
+
+    {site.logo}
+
+*`Referencing a partial to include in your template _foo.tmpl_:*
+
+    <div id="header">
+        {>logo/}
+        {site.nav}
+    </div>
+
+This would insert the output of the template _logo.tmpl_ into _foo.tmpl_.
+
+*Resulting markup of the combined _logo.tmpl_ and _foo.tmpl_ templates:*
+
+    <div id="header">
+        <h1>DemoCorp Inc.</h1>
+        <nav>
+            <ul>
+                <li><a href="/">Home</a></li>
+            </ul>
+        </nav>
+    </div>
+
+
+## 7\. `{+bar} ... {/bar}` - Block Placeholders
+
+Blocks allow you to define snippets of template code that may be overridden by any templates that reference this template:
+
+*Adding an overridable block `header` to _foo.tmpl_:*
+    {+header}Plain Old Default Header{/header}
+
+See *Block Overrides* below for override usage.
+
+
+## 8\. `{<bar} ... {/bar}` - Block Overrides
+
+Adding an overridable block `header` to _foo.tmpl_:
+
+    {+header}Plain Old Default Header{/header}
+    {>products/}
+
+Overrides the content of `header` in _foo.tmpl_ from within the included template _products.tmpl_:
+
+    {<header}Exciting New More Specific Products Header!{/header}
+    
+Note that special variable is available within a block that allows you to access the content that would otherwise be replaced from a block being overridden. This variable is called `\_SUPER\_` and it allows you to extend, instead of override, the previous contents of the block.
+
+    {<header}
+        {\_SUPER\_}
+    {/header}
+
+In our example above, the resulting contents of header with `\_SUPER\_` would be the contents of both headings combined:
+
+    Plain Old Default Header Exciting New More Specific Products Header!
+
+See 'Block Placeholders' above for placeholder usage.
+
+
+## 9\. `{?foo} ... {/foo}` - Conditional, Check For The Existence Of Variable `foo`
+
+Provide conditional output based on the existence of a variable.
+
+    {?user}
+        Welcome {user}.
+    {:else}
+        Please login.
+    {/user}
+
+
+## 10\. `{?foo} ... {/foo}` - Conditional, Check For The Non-existence Of Variable `foo`
+
+Provide conditional output based on the non-existence of a variable.
+    
+    {^user}
+        Please login.
+    {:else}
+        Welcome {user}.
+    {/user}
+
+
+## 11\. {%script} ... {/script} - Inline Script Pragma
+
+By default, templates collapse whitespace. This is a problem when templating elements where whitespace matters, like inline scripts featuring single-line comments. The `{%script}` pragma is provided to safely handle inline scripting in templates.
+
+    {%script}
+        // Show an alert dialog
+        alert("Hello Mobify!")
+    {/script}
+
+See [handling JavaScript] https://support.mobify.com/customer/portal/articles/513026-handling-javascript-with-mobify-js for more detail.
+
+
+## 12\. `{! Comment !}` - Template Comments
+
+Text surrounded by `{!` and `!}` are considered comments and will not be rendered.
+
+    {! 
+        Comments are useful for explaining complex template logic.
+    !}
+
+
+
+# Best Practices
+
+## Template File Naming Conventions
+
+Templates must be stored in your project folder under _src/tmpl_ using the _.tmpl_ file name extension:
+
+    <project>/src/tmpl/home.tmpl
+
+
+## Use A Base Template
+
+The bulk of your template logic should be inherited from another template using partials and blocks. For example, _base_:
+
+    <!DOCTYPE html>
+    <head>
+        {+head}{/head}
+    </head>
+    <body>
+        {+body}{/body}
+    </body>
+    </html>
+
+And in `home`:
+
+    {>base/}
+
+    {<head}
+        <title>Home</title>
+    {/head}
+
+    {<body}
+        <h1>Home</h1>
+    {/body}
+
+
+## Prefix Introduced Styling Attributes With `x-`
+
+Mobify.js preserves the attributes and content of elements selected from the source DOM. To differentiate between content from templates and content selected from the source DOM, it can be helpful to prefix any new attributes you introduce in your templates for the sake of styling.
+
+    <div class="x-banner">
+        {banner}
+    </div>
+
+We recommend you prefix all classes and IDs introduced in templates with `x-` to allow you to easily identify content introduced with the template.

--- a/docs/template-reference.md
+++ b/docs/template-reference.md
@@ -34,7 +34,7 @@ Note that when we talk about changing levels of context below, we simply mean tr
 
 ## 2\. `{foo}` - Variables: Select & Render A Single Variable
 
-Use any jQuery-like (Zepto) selector to select elements from your source DOM within the konf file. Reference the selection as a variable from any template using the curly brace syntax:
+Use any jQuery-like (Zepto.js) selector to select elements from your source DOM within the konf file. Reference the selection as a variable from any template using the curly brace syntax:
 
 *Original HTML input:*
 

--- a/docs/understanding-konf.md
+++ b/docs/understanding-konf.md
@@ -1,0 +1,58 @@
+# Understanding The Konf
+
+The konf file is JavaScript code written to select content from the source DOM. Selections made in the konf are used as the context for templates to render the mobile page. [Learn more about templates] https://support.mobify.com/customer/portal/articles/511698-understanding-templates
+
+A konf file is required in any Mobify project and by default lives at 'src/mobify.konf':
+
+    {>"/base/lib/base_konf.konf"/}
+    {<data} {
+
+    'OUTPUTHTML': function(context) {
+        return '<html><body><h1>HELLO MOBIFY!</h1></body></html>'
+    }
+
+    } {/data}
+
+Inside the `{<data} ... {/data}` block, we declare a JavaScript object called the konf object. Inside, we assign the key `OUTPUTHTML` to a function that returns an HTML string. When the konf object is evaluated, the function assigned to `OUTPUTHTML` gets called and the result is rendered to the browser immediately. Because of this, the `OUTPUTHTML` key should **always** be the last key assigned in the konf object.
+
+The konf object is an ordinary JavaScript object so we can add arbitrary keys to it:
+
+    {>"/base/lib/base_konf.konf"/}
+    {<data} {
+
+    'body': function(context) {
+        return $('body')
+    },
+    'OUTPUTHTML': function(context) {
+        return '<html><body><h1>HELLO MOBIFY!</h1></body></html>'
+    }
+
+    } {/data}
+
+Here we have added the key `body` whose contents are set to the result of evaluating the `$('body')` selector. `$` is assigned to a regular Zepto instance. We use it to make selections from the original desktop content, ie. the source DOM.
+
+Konf object values must always be anonymous functions that explicitly return the selected data:
+
+    // ERROR
+    'body': $('body')
+
+    // CORRECT
+    'body': function() {
+        return $('body')
+    }
+
+    // CORRECT
+    'body': function(context) {
+        return $('body')
+    }
+
+The `context` argument is optional, but enables additional functionality when passed:
+
+    'body': function() {
+        return $('body')
+    },
+    'img': function(context) {
+        return context.data('body').find('img')
+    }
+
+`context.choose`, `context.data`, and `context.tmpl` are functions that require `context` to be passed, [learn more about them] https://support.mobify.com/customer/portal/articles/511630-konf-reference

--- a/docs/understanding-konf.md
+++ b/docs/understanding-konf.md
@@ -1,6 +1,11 @@
+---
+layout: doc
+title: Understanding the Konf 
+---
+
 # Understanding The Konf
 
-The konf file is JavaScript code written to select content from the source DOM. Selections made in the konf are used as the context for templates to render the mobile page. [Learn more about templates] https://support.mobify.com/customer/portal/articles/511698-understanding-templates
+The konf file is JavaScript code written to select content from the source DOM. Selections made in the konf are used as the context for templates to render the mobile page. [Learn more about templates](https://support.mobify.com/customer/portal/articles/511698-understanding-templates)
 
 A konf file is required in any Mobify project and by default lives at 'src/mobify.konf':
 
@@ -55,4 +60,4 @@ The `context` argument is optional, but enables additional functionality when pa
         return context.data('body').find('img')
     }
 
-`context.choose`, `context.data`, and `context.tmpl` are functions that require `context` to be passed, [learn more about them] https://support.mobify.com/customer/portal/articles/511630-konf-reference
+`context.choose`, `context.data`, and `context.tmpl` are functions that require `context` to be passed, [learn more about them](https://support.mobify.com/customer/portal/articles/511630-konf-reference)

--- a/docs/understanding-templates.md
+++ b/docs/understanding-templates.md
@@ -1,0 +1,52 @@
+# Understanding Templates
+    
+In Mobify.js, templates are used to remix the source DOM and give you control over the output of your page. A template is a text file that contains regular HTML markup, plus variables that are replaced when the template is rendered. Context for the replacement variables comes from your project's konf, a file where you select objects from your original source DOM and match selections to specific templates. [Learn more about konf files] https://support.mobify.com/customer/portal/articles/511656-understanding-the-konf
+
+The following konf renders the `home` template to the browser:
+
+    'mobileSite': function(context) {
+        return context.choose({
+            'templateName': 'home',
+            '!products': function(context) {
+                return $('#products')
+            }
+        })
+    },
+    'OUTPUTHTML': function(context) {
+        var templateName = context.data('mobileSite.templateName')
+        if (templateName) {
+            return context.tmpl(templateName);
+        }
+    }
+
+A common pattern is to create an object in konf that selects data from the source DOM, then call `context.tmpl(templateName)` and assign the result to the `OUTPUTHTML` key.
+
+In this example, if the `home` object was matched, then the value `home` will be assigned to the key `mobileSite.templateName`. Mobify.js compiles files matching _/src/tmpl/*.tmpl_ and makes them available to the `context.tmpl` function under their filename. This example would render the template _home_, which is compiled from _src/tmpl/home.tmpl_. This is explained in more detail in the [konf reference] https://support.mobify.com/customer/portal/articles/511630-konf-reference
+
+Templates are text files that construct a HTML document. The _home_ template could look like this:
+
+    <!DOCTYPE html>
+    <html>
+    <head><title>Home</title></head>
+    <body>
+        <ul>
+            {#content.products}
+                <li>{.}</li>
+            {/content.products}
+        </ul>
+    </body>
+    </html>
+
+Assuming that the key `content.products` originally selected `&lt;div&gt;` nodes, calling `context.tmpl('home')` would evaluate the template with the selected data, producing the following markup:
+
+    <!DOCTYPE html>
+    <html>
+    <head><title>Homepage</title></head>
+    <body>
+        <ul>
+            <li><div>Product 1</div></li>
+            <li><div>Product 2</div></li>
+            <li><div>Product 3</div></li>
+        </ul>
+    </body>
+    </html>

--- a/docs/understanding-templates.md
+++ b/docs/understanding-templates.md
@@ -1,6 +1,11 @@
+---
+layout: doc
+title: Understanding Templates 
+---
+
 # Understanding Templates
     
-In Mobify.js, templates are used to remix the source DOM and give you control over the output of your page. A template is a text file that contains regular HTML markup, plus variables that are replaced when the template is rendered. Context for the replacement variables comes from your project's konf, a file where you select objects from your original source DOM and match selections to specific templates. [Learn more about konf files] https://support.mobify.com/customer/portal/articles/511656-understanding-the-konf
+In Mobify.js, templates are used to remix the source DOM and give you control over the output of your page. A template is a text file that contains regular HTML markup, plus variables that are replaced when the template is rendered. Context for the replacement variables comes from your project's konf, a file where you select objects from your original source DOM and match selections to specific templates. [Learn more about konf files](https://support.mobify.com/customer/portal/articles/511656-understanding-the-konf)
 
 The following konf renders the `home` template to the browser:
 
@@ -21,7 +26,7 @@ The following konf renders the `home` template to the browser:
 
 A common pattern is to create an object in konf that selects data from the source DOM, then call `context.tmpl(templateName)` and assign the result to the `OUTPUTHTML` key.
 
-In this example, if the `home` object was matched, then the value `home` will be assigned to the key `mobileSite.templateName`. Mobify.js compiles files matching _/src/tmpl/*.tmpl_ and makes them available to the `context.tmpl` function under their filename. This example would render the template _home_, which is compiled from _src/tmpl/home.tmpl_. This is explained in more detail in the [konf reference] https://support.mobify.com/customer/portal/articles/511630-konf-reference
+In this example, if the `home` object was matched, then the value `home` will be assigned to the key `mobileSite.templateName`. Mobify.js compiles files matching _/src/tmpl/\*.tmpl_ and makes them available to the `context.tmpl` function under their filename. This example would render the template _home_, which is compiled from _src/tmpl/home.tmpl_. This is explained in more detail in the [konf reference](https://support.mobify.com/customer/portal/articles/511630-konf-reference).
 
 Templates are text files that construct a HTML document. The _home_ template could look like this:
 


### PR DESCRIPTION
Have re-written the technical documentation to be more user-friendly. Would appreciate a second and third pair of eyeballs on this before merging, lots of stuff changed.

Most significant things to note:
- Added new 'Using Konf' section to konf reference, could be considered a candidate for replacing the entirety of 'Understanding Konf'
- fleshed out Reserved Keys in konf reference
- Added glossary, appendix
- Standardized wording in templates (variables and attributes)
- dropped sections in templates, seemed redundant when we already have variables and attributes
- added tons of code examples

Probably a bunch more I'm missing too.
