### PR TITLE
base_root.tmpl meta tag fix

### DIFF
--- a/tmpl/base_root.tmpl
+++ b/tmpl/base_root.tmpl
@@ -57,7 +57,7 @@ Below is your base template file, which is extended by home.tmpl:
     {+head}
         {$head|innerHTML|s}
         <link rel="stylesheet" href="{config.configDir}style.css" />
-        <meta name="viewport" content="width=device-width; initial-scale=1.0; minimum-scale=1.0; maximum-scale=1.0; user-scalable=no;" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     {/head}
 </head>
 {$body|openTag|s}


### PR DESCRIPTION
Corrected the viewport meta tag. (Resloves 5 errors and warnings on iPad and iPhone browsers.)
