### PR TITLE
Expose project name

### DIFF
--- a/api/resizeImages.js
+++ b/api/resizeImages.js
@@ -15,8 +15,6 @@ var absolutify = document.createElement('a')
       , '//ir3.mobify.com'
     ]
 
-    , projectName = Mobify.conf.projectName || ""
-
     /**
      * Hash `url` into a well distributed int.
      */

--- a/api/resizeImages.js
+++ b/api/resizeImages.js
@@ -46,8 +46,8 @@ var absolutify = document.createElement('a')
           , bits = [host];
 
         // If projectName is set on defaults and truthy, put it in resized image urls
-        if(defaults.projectName) {
-            var projectIdeintifier = "project-" + defaults.projectName
+        if (defaults.projectName) {
+            var projectIdeintifier = "project-" + defaults.projectName;
             bits.push(projectIdeintifier);
         }
 
@@ -94,9 +94,10 @@ var absolutify = document.createElement('a')
         return $imgs.each(function() {
             if (attr = this.getAttribute(opts.attribute)) {
                 absolutify.href = attr;
+                var url = absolutify.href;
                 // Produce an image resize url only for matched protocols
-                if(protocolMatcher.exec(absolutify.href)) {
-                    this.setAttribute('x-src', getImageURL(absolutify.href, opts))
+                if(protocolMatcher.exec(url)) {
+                    this.setAttribute('x-src', getImageURL(url, opts));
                 }
             }
         });

--- a/api/resizeImages.js
+++ b/api/resizeImages.js
@@ -46,7 +46,7 @@ var absolutify = document.createElement('a')
           , bits = [host];
 
         // If a projectName is set on the conf object, put it in resized image urls
-        if(Mobify.conf && && Mobify.conf.data && Mobify.conf.data.projectName) {
+        if(Mobify.conf && Mobify.conf.data && Mobify.conf.data.projectName) {
             var projectName = Mobify.conf.data.projectName
             var projectIdeintifier = "project-" + projectName
             bits.push(projectIdeintifier);

--- a/api/resizeImages.js
+++ b/api/resizeImages.js
@@ -5,6 +5,8 @@
 (function(window, $) {
 
 var absolutify = document.createElement('a')
+    // A regex for detecting http(s) URLs
+  , protocolMatcher = /^http(s)?/
 
   , hosts = [
         '//ir0.mobify.com'
@@ -95,7 +97,10 @@ var absolutify = document.createElement('a')
         return $imgs.each(function() {
             if (attr = this.getAttribute(opts.attribute)) {
                 absolutify.href = attr;
-                this.setAttribute('x-src', getImageURL(absolutify.href, opts))
+                // Produce an image resize url only for matched protocols
+                if(protocolMatcher.exec(absolutify.href)) {
+                    this.setAttribute('x-src', getImageURL(absolutify.href, opts))
+                }
             }
         });
     }

--- a/api/resizeImages.js
+++ b/api/resizeImages.js
@@ -43,8 +43,14 @@ var absolutify = document.createElement('a')
         options = options || {}
 
         var host = hosts[URLHash(url) % hosts.length]
-          , projectIdeintifier = "project-" + projectName
           , bits = [host];
+
+        // If a projectName is set on the conf object, put it in resized image urls
+        if(Mobify.conf && Mobify.conf.projectName) {
+            var projectName = Mobify.conf.projectName
+            var projectIdeintifier = "project-" + projectName
+            bits.push(projectIdeintifier);
+        }
 
         if (options.format) {
             bits.push(options.format + (options.quality || ''));

--- a/api/resizeImages.js
+++ b/api/resizeImages.js
@@ -45,10 +45,9 @@ var absolutify = document.createElement('a')
         var host = hosts[URLHash(url) % hosts.length]
           , bits = [host];
 
-        // If a projectName is set on the conf object, put it in resized image urls
-        if(Mobify.conf && Mobify.conf.data && Mobify.conf.data.projectName) {
-            var projectName = Mobify.conf.data.projectName
-            var projectIdeintifier = "project-" + projectName
+        // If projectName is set on defaults and truthy, put it in resized image urls
+        if(defaults.projectName) {
+            var projectIdeintifier = "project-" + defaults.projectName
             bits.push(projectIdeintifier);
         }
 
@@ -105,6 +104,7 @@ var absolutify = document.createElement('a')
   , defaults = resizeImages.defaults = {
         selector: 'img[x-src]'
       , attribute: 'x-src'
+      , projectName: ''
     }
 
 })(this, Mobify.$);

--- a/api/resizeImages.js
+++ b/api/resizeImages.js
@@ -13,6 +13,8 @@ var absolutify = document.createElement('a')
       , '//ir3.mobify.com'
     ]
 
+    , projectName = Mobify.conf.projectName || ""
+
     /**
      * Hash `url` into a well distributed int.
      */
@@ -41,6 +43,7 @@ var absolutify = document.createElement('a')
         options = options || {}
 
         var host = hosts[URLHash(url) % hosts.length]
+          , projectIdeintifier = "project-" + projectName
           , bits = [host];
 
         if (options.format) {

--- a/api/resizeImages.js
+++ b/api/resizeImages.js
@@ -46,8 +46,8 @@ var absolutify = document.createElement('a')
           , bits = [host];
 
         // If a projectName is set on the conf object, put it in resized image urls
-        if(Mobify.conf && Mobify.conf.projectName) {
-            var projectName = Mobify.conf.projectName
+        if(Mobify.conf && && Mobify.conf.data && Mobify.conf.data.projectName) {
+            var projectName = Mobify.conf.data.projectName
             var projectIdeintifier = "project-" + projectName
             bits.push(projectIdeintifier);
         }

--- a/docs/konf-reference.md
+++ b/docs/konf-reference.md
@@ -317,6 +317,8 @@ following reserved keys:
 
 `mobileViewport`: Contents of the meta viewport tag to be sent
 
+`projectName`: The Mobify project's name, as taken from project.json
+
 `siteConfig`: An object containing analytics configuration information
 
 `touchIcon`: The location of a file to be used as the bookmark icon for this website on iOS devices

--- a/konf/api_config.konf
+++ b/konf/api_config.konf
@@ -1,0 +1,12 @@
+(function(Mobify) {
+
+{! project "name" slug from project.json !}
+{?project_name}
+
+var projectName = '{project_name}';
+
+Mobify.$.fn.resizeImages.defaults.projectName = projectName;
+
+{/project_name}
+
+})(window.Mobify);

--- a/konf/api_config.konf
+++ b/konf/api_config.konf
@@ -1,3 +1,5 @@
+{! API Configuration !}
+
 (function(Mobify) {
 
 {! project "name" slug from project.json !}
@@ -5,6 +7,7 @@
 
 var projectName = '{project_name}';
 
+{! Add it to image resizing defaults !}
 Mobify.$.fn.resizeImages.defaults.projectName = projectName;
 
 {/project_name}

--- a/konf/base.konf
+++ b/konf/base.konf
@@ -54,6 +54,8 @@
 {>"/base/api/main.js"/}
 {>"/base/api/resizeImages.js"/}
 
+{>"api_config.konf"/}
+
 {+tmpl}
     {>"/base/tmpl/*.tmpl"/}
     {>"tmpl/*.tmpl"/}

--- a/konf/base.konf
+++ b/konf/base.konf
@@ -54,7 +54,7 @@
 {>"/base/api/main.js"/}
 {>"/base/api/resizeImages.js"/}
 
-{>"api_config.konf"/}
+{>"/base/konf/api_config.konf"/}
 
 {+tmpl}
     {>"/base/tmpl/*.tmpl"/}

--- a/konf/base.konf
+++ b/konf/base.konf
@@ -54,6 +54,7 @@
 {>"/base/api/main.js"/}
 {>"/base/api/resizeImages.js"/}
 
+{! configure API defaults before transform !}
 {>"/base/konf/api_config.konf"/}
 
 {+tmpl}

--- a/konf/defaults.konf
+++ b/konf/defaults.konf
@@ -26,7 +26,7 @@
 
     //Project name slug from project.json
     {?project_name}
-    projectName: {project_name},
+    projectName: '{project_name}',
     {/project_name}
     
     // Timestamp when this string was made.

--- a/konf/defaults.konf
+++ b/konf/defaults.konf
@@ -23,6 +23,11 @@
     
     // Populated from `site.json`.
     siteConfig: {site_config|s},
+
+    //Project name slug from project.json
+    {?project_name}
+    projectName: {project_name},
+    {/project_name}
     
     // Timestamp when this string was made.
     buildDate: {build_dt},

--- a/konf/defaults.konf
+++ b/konf/defaults.konf
@@ -23,11 +23,6 @@
     
     // Populated from `site.json`.
     siteConfig: {site_config|s},
-
-    //Project name slug from project.json
-    {?project_name}
-    projectName: '{project_name}',
-    {/project_name}
     
     // Timestamp when this string was made.
     buildDate: {build_dt},

--- a/tests/index.html
+++ b/tests/index.html
@@ -420,14 +420,14 @@
         test('Mobify.getImageURL - projectName set on Mobify.conf.data', function() {
             expect(1);
             
-            Mobify.conf.data.projectName = 'testing'
+            Mobify.$.fn.resizeImages.defaults.projectName = 'testing'
 
             got = Mobify.getImageURL('http://test/image.jpg', {maxWidth: 320});
             vow = "//ir2.mobify.com/project-testing/320/http://test/image.jpg"
 
             equal(got, vow);
 
-            delete Mobify.conf.projectName;
+            delete Mobify.$.fn.resizeImages.defaults.projectName;
         });
 
 

--- a/tests/index.html
+++ b/tests/index.html
@@ -25,7 +25,7 @@
 
     <div id="fixtures">
         <script>
-        Mobify = { points: [+new Date], config: {}, conf: { data: {} } }
+        Mobify = { points: [+new Date], config: {}, conf: { data: {} } };
         </script>
         <script src="../vendor/zepto/src/zepto.js"></script>
         <script src="../vendor/zepto/src/event.js"></script>
@@ -395,9 +395,9 @@
         test('$.fn.resizeImages non-http-url', function() {
             expect(1);
 
-            $('#resizeImages-non-http').resizeImages()
-            var i = $('#resizeImages-non-http img')
-            var url = i.attr('x-src')
+            $('#resizeImages-non-http').resizeImages();
+            var i = $('#resizeImages-non-http img');
+            var url = i.attr('x-src');
 
             equal(url, "gopher://archie.ftp.mailto/somanyprotocols", 
                 "Non-http url unchanged");
@@ -420,10 +420,10 @@
         test('Mobify.getImageURL - projectName set on Mobify.conf.data', function() {
             expect(1);
             
-            Mobify.$.fn.resizeImages.defaults.projectName = 'testing'
+            Mobify.$.fn.resizeImages.defaults.projectName = 'testing';
 
             got = Mobify.getImageURL('http://test/image.jpg', {maxWidth: 320});
-            vow = "//ir2.mobify.com/project-testing/320/http://test/image.jpg"
+            vow = "//ir2.mobify.com/project-testing/320/http://test/image.jpg";
 
             equal(got, vow);
 
@@ -434,8 +434,8 @@
         module('enhance');
 
         test('Mobify.enhance', function() {
-            Mobify.enhance()
-            ok(1)
+            Mobify.enhance();
+            ok(1);
         });
 
 

--- a/tests/index.html
+++ b/tests/index.html
@@ -74,6 +74,10 @@
         <img x-src="http://www.mobify.com/i/phone-tablet.png" />
     </div>
 
+    <div id="resizeImages-non-http">
+        <img x-src="gopher://archie.ftp.mailto/somanyprotocols" />
+    </div>
+
 
     <script id="test-disable-1" type="text/test">
         <link href="style.css" />
@@ -381,9 +385,20 @@
         module('resizeImages');
 
         test('$.fn.resizeImages', function() {
-            var $got = $('#resizeImages').resizeImages()
+            var $got = $('#resizeImages').resizeImages();
 
             equal($got.length, 1);
+        });
+
+        test('$.fn.resizeImages non-http-url', function() {
+            expect(1);
+
+            $('#resizeImages-non-http').resizeImages()
+            var i = $('#resizeImages-non-http img')
+            var url = i.attr('x-src')
+
+            equal(url, "gopher://archie.ftp.mailto/somanyprotocols", 
+                "Non-http url unchanged");
         });
 
         test('Mobify.getImageURL', function() {

--- a/tests/index.html
+++ b/tests/index.html
@@ -24,7 +24,9 @@
     <ol id="qunit-tests"></ol>  
 
     <div id="fixtures">
-        <script>Mobify = {points: [+new Date], config: {}, conf: {} }</script>
+        <script>
+        Mobify = { points: [+new Date], config: {}, conf: { data: {} } }
+        </script>
         <script src="../vendor/zepto/src/zepto.js"></script>
         <script src="../vendor/zepto/src/event.js"></script>
 
@@ -415,10 +417,10 @@
             equal(got, vow);
         });
 
-        test('Mobify.getImageURL - projectName set on Mobify.conf', function() {
+        test('Mobify.getImageURL - projectName set on Mobify.conf.data', function() {
             expect(1);
             
-            Mobify.conf.projectName = 'testing'
+            Mobify.conf.data.projectName = 'testing'
 
             got = Mobify.getImageURL('http://test/image.jpg', {maxWidth: 320});
             vow = "//ir2.mobify.com/project-testing/320/http://test/image.jpg"

--- a/tests/index.html
+++ b/tests/index.html
@@ -24,7 +24,7 @@
     <ol id="qunit-tests"></ol>  
 
     <div id="fixtures">
-        <script>Mobify = {points: [+new Date], config: {}}</script>
+        <script>Mobify = {points: [+new Date], config: {}, conf: {} }</script>
         <script src="../vendor/zepto/src/zepto.js"></script>
         <script src="../vendor/zepto/src/event.js"></script>
 
@@ -387,6 +387,8 @@
         });
 
         test('Mobify.getImageURL', function() {
+            expect(2);
+
             var got = Mobify.getImageURL('http://test/image.jpg')
               , vow = '//ir2.mobify.com/http://test/image.jpg';
 
@@ -396,6 +398,19 @@
             vow = '//ir2.mobify.com/320/http://test/image.jpg';
 
             equal(got, vow);
+        });
+
+        test('Mobify.getImageURL - projectName set on Mobify.conf', function() {
+            expect(1);
+            
+            Mobify.conf.projectName = 'testing'
+
+            got = Mobify.getImageURL('http://test/image.jpg', {maxWidth: 320});
+            vow = "//ir2.mobify.com/project-testing/320/http://test/image.jpg"
+
+            equal(got, vow);
+
+            delete Mobify.conf.projectName;
         });
 
 


### PR DESCRIPTION
Changes to mobifyjs API  and build necessary to expose the project name on imageresize's defaults object, note, requires modifications to mobify client to build a mobify.js that does this (these modifications have been completed on a similarly named branch of mobify-client)
