### PR TITLE
Add buildstatic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,4 +18,10 @@ modules:
 	zip -r ../downloads/accordion.zip accordion; \
 	zip -r ../downloads/zoomable.zip zoomable
 
+buildstatic: modules ; \
+    cd www ; \
+    jekyll ; \
+    rm static/downloads/*
+    
+
 .PHONY: modules

--- a/Makefile
+++ b/Makefile
@@ -18,10 +18,10 @@ modules:
 	zip -r ../downloads/accordion.zip accordion; \
 	zip -r ../downloads/zoomable.zip zoomable
 
-buildstatic: modules ; \
+buildstatic:
+	modules ; \
     cd www ; \
     jekyll ; \
     rm static/downloads/*
-    
 
 .PHONY: modules

--- a/README.md
+++ b/README.md
@@ -36,6 +36,14 @@ Then navigate to http://localhost:4000/mobifyjs/docs/.
 Mobify.js includes a library customizable user interface modules in the
 `modules` folder.
 
-To package the modules for download use this command:
+To package the modules for download use this command (they will be stored in /static/downloads):
 
     make modules
+
+## Build mobifyjs.com
+
+When creating a build of mobifyjs.com for release, execute this command:
+
+    make buildstatic
+
+And then copy the generated "\_site" folder to where the site will be hosted.

--- a/www/modules/accordion.md
+++ b/www/modules/accordion.md
@@ -4,7 +4,7 @@ title: Mobify.js Accordion Module
 ---
 
 <link rel="stylesheet" href="{{ site.baseurl }}/static/modules/accordion/accordion.css">
-<link rel="stylesheet" href="{{ site.baseurl }}/static/modules/accordion/css/accordion-style.css">
+<link rel="stylesheet" href="{{ site.baseurl }}/static/modules/accordion/accordion-style.css">
 
 # Accordion
 

--- a/www/static/downloads/.gitignore
+++ b/www/static/downloads/.gitignore
@@ -1,0 +1,6 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore
+
+# This file is necessary to have a empty folder in a git repository


### PR DESCRIPTION
Adds command to build entire static mobifyjs.com site, including the modules.
