### PR TITLE
Image resizer: prevent defaults from being overwritten

### DIFF
--- a/api/resizeImages.js
+++ b/api/resizeImages.js
@@ -48,7 +48,7 @@ var $ = Mobify.$
      * resized.
      */
   , resizeImages = $.fn.resizeImages = function(options) {
-        var opts = $.extend(defaults, typeof options == 'object' && options)
+        var opts = $.extend({}, defaults, typeof options == 'object' && options)
           , dpr = window.devicePixelRatio
           , $imgs = this.filter(opts.selector).add(this.find(opts.selector))
           , attr;

--- a/tests/index.html
+++ b/tests/index.html
@@ -406,6 +406,14 @@
             equal(got, vow, "Non-http url unchanged");
         });
 
+        test('$.fn.resizeImages defaults', function(assert) {
+            var defaults = $.fn.resizeImages.defaults
+              , oMaxWidth = defaults.maxWidth
+
+            $('#resizeImages-defaults').resizeImages({maxWidth: 1});
+            assert.equal(defaults.maxWidth, oMaxWidth);
+        });
+
         test('Mobify.getImageURL', function() {
             expect(2);
 


### PR DESCRIPTION
$.extend() actually mutates the first argument.
