### PR TITLE
fix accordion bug in latest Chrome and Firefox

### DIFF
--- a/www/static/modules/accordion/accordion.js
+++ b/www/static/modules/accordion/accordion.js
@@ -56,12 +56,34 @@ Mobify.UI.Utils = (function($) {
         return;
     };
 
+    // determine which transition event to use
+    function whichTransitionEvent(){
+        // http://stackoverflow.com/questions/5023514/how-do-i-normalize-css3-transition-functions-across-browsers
+        // hack for ios 3.1.* because of poor transition support.
+        if (/iPhone\ OS\ 3_1/.test(navigator.userAgent)) {
+            return undefined;
+        }
+
+        var el = document.createElement('fakeelement');
+        var transitions = {
+            'transition':'transitionEnd transitionend',
+            'OTransition':'oTransitionEnd',
+            'MSTransition':'msTransitionEnd',
+            'MozTransition':'transitionend',
+            'WebkitTransition':'webkitTransitionEnd'
+        }
+
+        var t;
+        for(t in transitions){
+            if( el.style[t] !== undefined ){
+                return transitions[t];
+            }
+        }
+        return;
+    };
+
     $.extend(exports.events, {
-        'transitionend': [  "transitionEnd",
-                            "oTransitionEnd",
-                            "msTransitionEnd",
-                            "transitionend",
-                            "webkitTransitionEnd" ].join(" ")
+        'transitionend': whichTransitionEvent()
      });
 
 

--- a/www/static/modules/accordion/accordion.js
+++ b/www/static/modules/accordion/accordion.js
@@ -56,34 +56,12 @@ Mobify.UI.Utils = (function($) {
         return;
     };
 
-    // determine which transition event to use
-    function whichTransitionEvent(){
-        // http://stackoverflow.com/questions/5023514/how-do-i-normalize-css3-transition-functions-across-browsers
-        // hack for ios 3.1.* because of poor transition support.
-        if (/iPhone\ OS\ 3_1/.test(navigator.userAgent)) {
-            return undefined;
-        }
-
-        var el = document.createElement('fakeelement');
-        var transitions = {
-            'transition':'transitionEnd',
-            'OTransition':'oTransitionEnd',
-            'MSTransition':'msTransitionEnd',
-            'MozTransition':'transitionend',
-            'WebkitTransition':'webkitTransitionEnd'
-        }
-
-        var t;
-        for(t in transitions){
-            if( el.style[t] !== undefined ){
-                return transitions[t];
-            }
-        }
-        return;
-    };
-
     $.extend(exports.events, {
-        'transitionend': whichTransitionEvent()
+        'transitionend': [  "transitionEnd",
+                            "oTransitionEnd",
+                            "msTransitionEnd",
+                            "transitionend",
+                            "webkitTransitionEnd" ].join(" ")
      });
 
 


### PR DESCRIPTION
Fix according by binding all browser-specific transitionend events. Detection mechanism we use to determine which transitionend event to use is broken in Chrome dev build (26) and Firefox 18. Likely a bug to send to browser venders (TODO: Writeup minimal testcase on JSFiddle!)
