### PR TITLE
Call toString on Error objects when logging to console.

### DIFF
--- a/api/logging.js
+++ b/api/logging.js
@@ -23,8 +23,11 @@
             if (obj) {
                 $.each(obj, function(key, value) {
                     noneWritten && console.group(title);
+                    
                     if (typeof key == "number") {
                         console[fn].apply(window, value);
+                    } else if (value instanceof Error) {
+                        console.error(key, value.toString());
                     } else {
                         console[fn](key, value);
                     }


### PR DESCRIPTION
Proposed fix for #108.

Tested in Chrome 27 and Safari 6.

Your thoughts @noahadams @rrjamie?
