### PR TITLE
Make Jazzcat use inline scripts as default emission method. 

### DIFF
--- a/api/combo.js
+++ b/api/combo.js
@@ -288,7 +288,7 @@ var $ = Mobify.$
          * `document.write`. Prefer loading contents from cache.
          */
         exec: function(url, forceDataURI) {
-            var resource, safeSource;
+            var resource, safeSource, dataURI;
 
             if (resource = httpCache.get(url, true)) {
                 if (resource.text && !forceDataURI) {
@@ -318,13 +318,14 @@ var $ = Mobify.$
                     safeSource = resource.body.replace(/(<\/scr)(ipt\s*>)/ig, '$1\\$2');
                     return document.write('<script data-orig-src="' + url + '">' + safeSource + '<\/scr'+'ipt>');
                 } else {
-                    url = httpCache.utils.dataURI(resource);
+                    dataURI = httpCache.utils.dataURI(resource);
+                    return document.write('<script data-orig-src="' + url + '" src="' + dataURI + '"><\/scr' + 'ipt>');  
                 }
+            } else {
+                // Firefox will choke on closing script tags passed through
+                // the ark.
+                document.write('<script src="' + url + '"><\/scr' + 'ipt>');              
             }
-            
-            // Firefox will choke on closing script tags passed through
-            // the ark.
-            document.write('<script src="' + url + '"><\/scr' + 'ipt>');
         }
 
         /**

--- a/tests/index.html
+++ b/tests/index.html
@@ -142,6 +142,12 @@
     <iframe id="test-unmobify" src="fixtures/unmobify-basic.html"></iframe>
     <a href="fixtures-unmobify/basic.html">BASIC</a>
 
+    <script id="test-mobify-combo-exec" type="text/test">
+/*<\/script>*/
+"<\/script>"
+/<\/script>/
+    </script>
+
     <script>
         var $ = Mobify.$
           , httpCache = Mobify.httpCache
@@ -296,6 +302,51 @@
                 ok(httpCache.get(encodeURI(url)) != undefined, "Missing resource.");
                 start();
             });
+        });
+
+        test('Mobify.combo.exec', 5, function() {
+            var cache = {
+                'cached': {
+                    'headers': {'expires': UTC_TWO_WEEKS_FROM_NOW},
+                    'status': 'ready',
+                    'url': 'cached',
+                    'body': 'cached',
+                    'text': true
+                },
+                'cached-with-scripts': {
+                    'headers': {'expires': UTC_TWO_WEEKS_FROM_NOW},
+                    'status': 'ready',
+                    'url': 'cached-with-scripts',
+                    'body': getText("#test-mobify-combo-exec"),
+                    'text': true
+                }
+            };
+
+            httpCache.reset(cache);
+
+            var nativeDocumentWrite = document.write
+            document.write = function(s) {
+                wrote = s
+            }
+
+            try {
+                Mobify.combo.exec('cached');
+                equal(wrote, '<script data-orig-src="cached">cached<\/script>');
+
+                Mobify.combo.exec('uncached');
+                equal(wrote, '<script src="uncached"><\/script>');
+
+                Mobify.combo.exec('cached-with-scripts');
+                equal(wrote, '<script data-orig-src=\"cached-with-scripts\">/*<\/scr\\ipt>*/ \"<\/scr\\ipt>\" \/<\/scr\\ipt>\/<\/script>');
+
+                Mobify.combo.exec('cached');
+                equal(wrote, '<script data-orig-src="cached">cached<\/script>');
+
+                Mobify.combo.exec('cached', true);
+                equal(wrote, '<script data-orig-src="cached" src="data:application/x-javascript,cached"><\/script>');
+            } finally {
+                document.write = nativeDocumentWrite;
+            }
         });
 
         asyncTest('httpCache - Eviction on an unused resource', 2, function() {


### PR DESCRIPTION
Allow use of old approach via forceDataURI flag.

Performance improvements verified on iPhone 3GS with iOS 5.0.1. Correctness of escaping method itself tested on nearly all device library handsets via testcase below:

&lt;!DOCTYPE&gt;<br/>&lt;html&gt;<br/>&lt;head&gt;&lt;title&gt;truetrue = Script escaping works&lt;/title&gt;<br/>&lt;/head&gt;<br/>&lt;body&gt;<br/>   &lt;script&gt;<br/>     /_&lt;/scr\ipt&gt;_/<br/>       document.write(&quot;&lt;/scr\ipt&gt;&quot; === &quot;&lt;/scr&quot; + &quot;ipt&gt;&quot;);<br/>       document.write(/scr\ipt&gt;/.exec(&quot;script&gt;&quot;).length === 1);<br/>   &lt;/script&gt;<br/>&lt;/body&gt;<br/>&lt;/html&gt;
