### PR TITLE
Run make install before tests

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,5 @@
+test:
+    pre:
+        - make install
+    override:
+        - make test


### PR DESCRIPTION
Run make install before tests run.  This initializes the zepto submodule and makes sure tests don't barf.
