### PR TITLE
Adding a count helper to dust that starts at 1 instead of 0.

### DIFF
--- a/vendor/dust-core.js
+++ b/vendor/dust-core.js
@@ -448,6 +448,10 @@ dust.helpers = {
 
   idx: function(chunk, context, bodies) {
     return bodies.block(chunk, context.push(context.stack.index));
+  },
+
+  count: function(chunk, context, bodies) {
+    return bodies.block(chunk, context.push(context.stack.index + 1));
   }
 }
 


### PR DESCRIPTION
Adds a new helper to dust - @count

E.g;

```
{#carousel}
     <a href="#" class="m-dot" data-slide"{@count}{.}{/count}">{@count}{.}{/count}</a>
{#carousel}
```

When using {@idx} there are a bunch of situations where the desired behaviour is not obtained due to it being 0-based.

For example, the code above could output the following when using @idx:

```
<a href="#" class="m-dot" data-slide=""></a>
<a href="#" class="m-dot m-active" data-slide="1">1</a>
<a href="#" class="m-dot" data-slide="2">2</a>
```
