### PR TITLE
adds use of project name parameter to mobify 1.1 jazzcat implementation,...

### DIFF
--- a/api/combo.js
+++ b/api/combo.js
@@ -275,9 +275,12 @@ var $ = Mobify.$
   , defaults = combineScripts.defaults = {
         selector: 'script'
       , attribute: 'x-src'
-      , endpoint: '//jazzcat.mobify.com/jsonp/'
+      , proto: '//'
+      , host: 'jazzcat.mobify.com'
+      , endpoint: 'jsonp'
       , execCallback: 'Mobify.combo.exec'
       , loadCallback: 'Mobify.combo.load'
+      , projectName: Mobify.config.projectName || ''
     }
 
   , combo = Mobify.combo = {
@@ -353,8 +356,11 @@ var $ = Mobify.$
      * Returns a URL suitable for use with the combo service. Sorted to generate
      * consistent URLs.
      */
-  , getURL = function(urls, callback) {
-        return defaults.endpoint + callback + '/' + JSONURIencode(urls.slice().sort());
+  , getURL = Mobify.combo.getURL = function(urls, callback) {
+        return defaults.proto + defaults.host + 
+          (defaults.projectName ? '/project-' + defaults.projectName : '') + 
+          '/' + defaults.endpoint + '/' + callback + '/' +
+          JSONURIencode(urls.slice().sort());
     }
 
   , JSONURIencode = Mobify.JSONURIencode = function(obj) {
@@ -365,8 +371,11 @@ $.fn.combineScripts = function(opts) {
     return combineScripts.call(window, this, opts)
 }
 
+// expose defaults for testing
+$.fn.combineScripts.defaults = combineScripts.defaults;
+
 Mobify.cssURL = function(obj) {
-    return '//combo.mobify.com/css/' + JSONURIencode(obj)
+    return '//jazzcat.mobify.com/css/' + JSONURIencode(obj)
 }
 
 })(this, document, Mobify);

--- a/tests/index.html
+++ b/tests/index.html
@@ -186,7 +186,17 @@
         module('combo')
 
         test('Mobify.cssURL - It exists', function() {
-            ok(Mobify.cssURL({}))
+            ok(Mobify.cssURL({}));
+        });
+
+        test('combo - getURL', function() {
+            Mobify.$.fn.combineScripts.defaults.projectName = "foo";
+            var url = Mobify.combo.getURL(["https://www.example.com/baz/qux.js",
+                "http://www.example.com/qux/baz.js"], "bar")
+              , expected = "//jazzcat.mobify.com/project-foo/jsonp/bar/%5B%22http%3A%2F%2Fwww.example.com%2Fqux%2Fbaz.js%22%2C%22https%3A%2F%2Fwww.example.com%2Fbaz%2Fqux.js%22%5D"; 
+
+            
+            equal(url, expected);
         });
 
         asyncTest('combo - Warm cache', 1, function() {


### PR DESCRIPTION
... also refactors the url generating function and adds a test for it
