### PR TITLE
V1.1 jazzcat document write ref

### DIFF
--- a/api/combo.js
+++ b/api/combo.js
@@ -281,6 +281,8 @@ var $ = Mobify.$
     }
 
   , combo = Mobify.combo = {
+        // a copy of document.write in case it is reassigned by other scripts
+        _docWrite: document.write,
         /**
          * Emit a <script> tag to execute the contents of `url` using
          * `document.write`. Prefer loading contents from cache.
@@ -323,7 +325,7 @@ var $ = Mobify.$
                 }
             }
 
-            document.write('<script ' + out + '<\/script>');
+            Mobify.combo._docWrite.call(document, '<script ' + out + '<\/script>');
         }
 
         /**

--- a/tests/index.html
+++ b/tests/index.html
@@ -148,6 +148,10 @@
 /<\/script>/
     </script>
 
+    <script id="test-mobify-combo-exec-document-write-override" type="text/test">
+    document.write = function() {console.log("moo!");};
+    </script>
+
     <script>
         var $ = Mobify.$
           , httpCache = Mobify.httpCache
@@ -306,7 +310,7 @@
             });
         });
 
-        test('Mobify.combo.exec', 5, function() {
+        test('Mobify.combo.exec', 6, function() {
             var cache = {
                 'cached': {
                     'headers': {'expires': UTC_TWO_WEEKS_FROM_NOW},
@@ -320,6 +324,13 @@
                     'status': 'ready',
                     'url': 'cached-with-scripts',
                     'body': getText("#test-mobify-combo-exec"),
+                    'text': true
+                },
+                'override-document-write': {
+                    'headers': {'expires': UTC_TWO_WEEKS_FROM_NOW},
+                    'status' : 'ready',
+                    'url': 'override-document-write',
+                    'body': getText("#test-mobify-combo-exec-document-write-override"),
                     'text': true
                 }
             };
@@ -346,6 +357,13 @@
 
                 Mobify.combo.exec('cached', true);
                 equal(wrote, '<script data-orig-src="cached" src="data:application/x-javascript,cached"><\/script>');
+
+                // test execing a functiont hat overrides a document.write
+                Mobify.combo.exec('override-document-write');
+                equal(wrote, '<script data-orig-src="override-document-write">document.write = function() {console.log("moo!");};<\/script>');
+                // restore regular old document.write after this exec
+                document.write = Mobify.combo._docWrite;
+
             } finally {
                 Mobify.combo._docWrite = origDocWrite;
             }

--- a/tests/index.html
+++ b/tests/index.html
@@ -326,8 +326,8 @@
 
             httpCache.reset(cache);
 
-            var nativeDocumentWrite = document.write
-            document.write = function(s) {
+            var origDocWrite = Mobify.combo._docWrite
+            Mobify.combo._docWrite = function(s) {
                 wrote = s
             }
 
@@ -347,7 +347,7 @@
                 Mobify.combo.exec('cached', true);
                 equal(wrote, '<script data-orig-src="cached" src="data:application/x-javascript,cached"><\/script>');
             } finally {
-                document.write = nativeDocumentWrite;
+                Mobify.combo._docWrite = origDocWrite;
             }
         });
 


### PR DESCRIPTION
Keeps a reference to the load-time implementation of document.write around in case it is later re-assigned by another script.
