### PR TITLE
clean up attribute getting/setting code

### DIFF
--- a/examples/resizeImages-img-element/index.html
+++ b/examples/resizeImages-img-element/index.html
@@ -86,7 +86,7 @@ setTimeout(function() {
     },
 
     '/mobifyjs/build/mobify.min.js',
-    '/mobifyjs/examples/resizeImages/main.js'
+    '/mobifyjs/examples/resizeImages-img-element/main.js'
     //'/build/custom/mobify.js'
 );
 </script>

--- a/src/resizeImages.js
+++ b/src/resizeImages.js
@@ -185,12 +185,12 @@ ResizeImages.getImageURL = function(url, options) {
  */
 
 ResizeImages._rewriteSrcAttribute = function(element, opts, srcVal){
-    srcVal = element.getAttribute(opts.attribute) || srcVal;
+    srcVal = element.getAttribute(opts.sourceAttribute) || srcVal;
     if (srcVal) {
         absolutify.href = srcVal;
         var url = absolutify.href;
         if (httpRe.test(url)) {
-            element.setAttribute(opts.setAttr, ResizeImages.getImageURL(url, opts));
+            element.setAttribute(opts.targetAttribute, ResizeImages.getImageURL(url, opts));
             element.setAttribute('data-orig-src', srcVal);
             if(opts.onerror) {
                 element.setAttribute('onerror', opts.onerror);
@@ -298,7 +298,8 @@ var defaults = {
       proto: '//',
       host: 'ir0.mobify.com',
       projectName: "oss-" + location.hostname.replace(/[^\w]/g, '-'),
-      attribute: "x-src",
+      sourceAttribute: "x-src",
+      targetAttribute: (capturing ? "x-src" : "src"),
       webp: ResizeImages.supportsWebp(),
       onerror: 'ResizeImages.restoreOriginalSrc(event);'
 };
@@ -310,8 +311,6 @@ var restoreOriginalSrc = ResizeImages.restoreOriginalSrc = function(event) {
         event.target.setAttribute('src', origSrc);
     }
 };
-
-defaults.setAttr = (capturing ? defaults.attribute : 'src');
 
 return ResizeImages;
 

--- a/tests/resizeImages.html
+++ b/tests/resizeImages.html
@@ -132,7 +132,7 @@
                 projectName: 'test1',
                 maxWidth: 320,
                 maxHeight: 480,
-                attribute: "data-src",
+                sourceAttribute: "data-src",
                 webp: false
             });
 
@@ -204,7 +204,7 @@
                 maxWidth: 1280,
                 maxHeight: 480,
                 webp: false,
-                attribute: 'src'
+                sourceAttribute: 'src'
             });
 
             var sources = images[0].getElementsByTagName('source');

--- a/www/v2/docs/image-resizer.md
+++ b/www/v2/docs/image-resizer.md
@@ -55,8 +55,10 @@ ir0.mobify.com will serve a 302 redirect back to the original image location.**
 
 **Options**
 
-- `attribute`: Attribute to manipulate for img/picture elements. Defaults to 
+- `sourceAttribute`: The attribute to get the source value from. Defaults to 
   "x-src". "x-" is the default escape prefix used in [Capturing](/mobifyjs/v2/docs/capturing/)
+- `targetAttribute`: The attribute to set witht he resized url. Defaults to 
+  "x-src" when capturing.
 - `cacheHours`: Sets the length of time for the image(s) to be cached on the CDN. 
   The default is 2 months.
 - `format`: Output format of the image(s) being resized. Defaults to original

--- a/www/v2/docs/image-resizer.md
+++ b/www/v2/docs/image-resizer.md
@@ -58,7 +58,7 @@ ir0.mobify.com will serve a 302 redirect back to the original image location.**
 - `sourceAttribute`: The attribute to get the source value from. Defaults to 
   "x-src". "x-" is the default escape prefix used in [Capturing](/mobifyjs/v2/docs/capturing/)
 - `targetAttribute`: The attribute to set witht he resized url. Defaults to 
-  "x-src" when capturing.
+  "x-src" when capturing, and "src" without capturing.
 - `cacheHours`: Sets the length of time for the image(s) to be cached on the CDN. 
   The default is 2 months.
 - `format`: Output format of the image(s) being resized. Defaults to original


### PR DESCRIPTION
Renames "attribute" and "setAttr" properties to sourceattribute and targetAtribute, and sets them up in a more consistent way.
