### PR TITLE
<img> onerror investigation

### DIFF
--- a/examples/resizeImages-handle-service-failure/onerrortests.html
+++ b/examples/resizeImages-handle-service-failure/onerrortests.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>img element onerror behaviour classifier</title>
+</head>
+<body>
+<style>
+img {
+    background-color: black;
+    border: 20px solid green;
+    min-width: 20px;
+    width: auto;
+}
+img:before {
+    content: attr(src);
+}
+</style>
+<script>
+window.ImageErrorHandler = function(event) {
+    console.dir(event);
+    event.target.setAttribute("style", "border: 20px solid red;");
+}
+</script>
+
+<img src ="http://garbage.domain.name.gfgrgrfgf/foo.jpg" onerror="ImageErrorHandler(event);" />
+<img src="/imagetests/textmime" onerror="ImageErrorHandler(event);" />
+<img src="/imagetests/emptyresponse" onerror="ImageErrorHandler(event);" />
+<img src="/imagetests/wrongmime" onerror="ImageErrorHandler(event);" />
+<img src="/imagetests/partialimage" onerror="ImageErrorHandler(event);" />
+<img src="/imagetests/abortedimage" onerror="ImageErrorHandler(event);" />
+<img src="/imagetests/notFound" onerror="ImageErrorHandler(event);" />
+<img src="/imagetests/serverError" onerror="ImageErrorHandler(event);" />
+<img src="/imagetests/fakejpeg" onerror="ImageErrorHandler(event);" />
+
+</body>
+</html>

--- a/examples/resizeImages-handle-service-failure/onerrortests.html
+++ b/examples/resizeImages-handle-service-failure/onerrortests.html
@@ -9,12 +9,10 @@
 img {
     background-color: black;
     border: 20px solid green;
-    min-width: 20px;
-    width: auto;
+    width: 100px;
+    margin-right: 10px;
 }
-img:before {
-    content: attr(src);
-}
+
 </style>
 <script>
 window.ImageErrorHandler = function(event) {
@@ -22,16 +20,47 @@ window.ImageErrorHandler = function(event) {
     event.target.setAttribute("style", "border: 20px solid red;");
 }
 </script>
+<div class="container">
+    <img src="http://garbage.domain.name.gfgrgrfgf/foo.jpg" onerror="ImageErrorHandler(event);" />
+    <span class="caption">http://garbage.domain.name.gfgrgrfgf/foo.jpg</span>
+</div>
+</script>
+<div class="container">
+    <img src="/imagetests/textmime" onerror="ImageErrorHandler(event);" />
+    <span class="caption">/imagetests/textmime</span>
+</div>
 
-<img src ="http://garbage.domain.name.gfgrgrfgf/foo.jpg" onerror="ImageErrorHandler(event);" />
-<img src="/imagetests/textmime" onerror="ImageErrorHandler(event);" />
-<img src="/imagetests/emptyresponse" onerror="ImageErrorHandler(event);" />
-<img src="/imagetests/wrongmime" onerror="ImageErrorHandler(event);" />
-<img src="/imagetests/partialimage" onerror="ImageErrorHandler(event);" />
-<img src="/imagetests/abortedimage" onerror="ImageErrorHandler(event);" />
-<img src="/imagetests/notFound" onerror="ImageErrorHandler(event);" />
-<img src="/imagetests/serverError" onerror="ImageErrorHandler(event);" />
-<img src="/imagetests/fakejpeg" onerror="ImageErrorHandler(event);" />
-
+<div class="container">
+    <img src="/imagetests/emptyresponse" onerror="ImageErrorHandler(event);" />
+    <span class="caption">/imagetests/emptyresponse</span>
+</div>
+<div class="container">
+    <img src="/imagetests/wrongmime" onerror="ImageErrorHandler(event);" />
+    <span class="caption">/imagetests/wrongmime</span>
+</div>
+<div class="container">
+    <img src="/imagetests/partialimage100b" onerror="ImageErrorHandler(event);" />
+    <span class="caption">/imagetests/partialimage100b</span>
+</div>
+<div class="container">
+    <img src="/imagetests/partialimage1k" onerror="ImageErrorHandler(event);" />
+    <span class="caption">/imagetests/partialimage1k</span>
+</div>
+<div class="container">
+    <img src="/imagetests/abortedimage" onerror="ImageErrorHandler(event);" />
+    <span class="caption">/imagetests/abortedimage</span>
+</div>
+<div class="container">
+    <img src="/imagetests/notFound" onerror="ImageErrorHandler(event);" />
+    <span class="caption">/imagetests/notFound</span>
+</div>
+<div class="container">
+    <img src="/imagetests/serverError" onerror="ImageErrorHandler(event);" />
+    <span class="caption">/imagetests/serverError</span>
+</div>
+<div class="container">
+    <img src="/imagetests/fakejpeg" onerror="ImageErrorHandler(event);" />
+    <span class="caption">/imagetests/fakejpeg</span>
+</div>
 </body>
 </html>

--- a/server.js
+++ b/server.js
@@ -4,6 +4,7 @@
 var http = require('http');
 var express = require('express');
 var fs = require('fs');
+var path = require('path');
 var Url = require('url');
 var hbs = require('hbs');
 
@@ -160,9 +161,56 @@ for (file in files) {
     scriptsObj[resourcesUrl + fileName] = fileData;
 }
 
-
-
 hbs.registerPartial('bootstrap', fs.readFileSync(__dirname + '/tag/bootstrap.html', 'utf8'));
+
+/**
+ * Image resizing error test cases
+ */
+
+var textMime = function(req, res) {
+    res.setHeader('Content-Type', 'text/plain');
+    res.end('Hello, World');
+};
+
+var emptyResponse = function(req, res) {
+    res.setHeader('Content-Type', 'image/jpeg');
+    res.end();
+};
+
+var imageData = fs.readFileSync(path.normalize('./examples/assets/images/grumpycat.jpg'));
+
+var wrongMime = function(req, res) {
+    res.setHeader('Content-Type', 'image/png');
+    res.end(imageData);    
+}
+
+var partialImage = function(req, res) {
+    res.setHeader('Content-Type', 'image/jpeg');
+    res.end(imageData.slice(0, 1024));
+};
+
+var abortedImage = function(req, res) {
+    res.setHeader('Content-Type', 'image/jpeg');
+    res.write(imageData.slice(0, 1024));
+    res.abort();
+}
+
+var notFound = function(req, res) {
+    res.statusCode = 404;
+    res.setHeader('Cotnent-Type', 'text/plain');
+    res.end('Not Found!');
+};
+
+var serverError = function(req, res) {
+    res.statusCode = 500;
+    res.setHeader('Content-Type', 'text/plain');
+    res.end('Faux Internal Server Error');
+};
+
+var fakeJPEG = function(req, res) {
+    res.setHeader('Content-Type', 'image/jpeg');
+    res.end('asdf');
+};
 
 var app = express();
 
@@ -183,6 +231,14 @@ app.get('/performance/jazzcat/runner/:numScripts', jazzcatPerformanceRunner);
 app.get('/jsonp/Jazzcat.load/:scripts', jazzcatJsonp);
 app.get('/js/:scripts', jazzcatJs);
 
+app.get('/imagetests/textmime', textMime);
+app.get('/imagetests/emptyresponse', emptyResponse);
+app.get('/imagetests/wrongmime', wrongMime);
+app.get('/imagetests/partialimage', partialImage);
+app.get('/imagetests/abortedimage', abortedImage);
+app.get('/imagetests/notFound', notFound);
+app.get('/imagetests/serverError', serverError);
+app.get('/imagetests/fakejpeg', fakeJPEG);
 
 if (require.main === module) {
     app.use(express.static(__dirname));

--- a/server.js
+++ b/server.js
@@ -181,19 +181,21 @@ var imageData = fs.readFileSync(path.normalize('./examples/assets/images/grumpyc
 
 var wrongMime = function(req, res) {
     res.setHeader('Content-Type', 'image/png');
-    res.end(imageData);    
-}
+    res.end(imageData);
+};
 
-var partialImage = function(req, res) {
-    res.setHeader('Content-Type', 'image/jpeg');
-    res.end(imageData.slice(0, 1024));
+var partialImage = function(bytes) {
+    return function(req, res) {
+        res.setHeader('Content-Type', 'image/jpeg');
+        res.end(imageData.slice(0, bytes));
+    };
 };
 
 var abortedImage = function(req, res) {
     res.setHeader('Content-Type', 'image/jpeg');
     res.write(imageData.slice(0, 1024));
-    res.abort();
-}
+    res.socket.destroy();
+};
 
 var notFound = function(req, res) {
     res.statusCode = 404;
@@ -234,7 +236,8 @@ app.get('/js/:scripts', jazzcatJs);
 app.get('/imagetests/textmime', textMime);
 app.get('/imagetests/emptyresponse', emptyResponse);
 app.get('/imagetests/wrongmime', wrongMime);
-app.get('/imagetests/partialimage', partialImage);
+app.get('/imagetests/partialimage100b', partialImage(100));
+app.get('/imagetests/partialimage1k', partialImage(1024));
 app.get('/imagetests/abortedimage', abortedImage);
 app.get('/imagetests/notFound', notFound);
 app.get('/imagetests/serverError', serverError);


### PR DESCRIPTION
Adds an example that illustrates when an "error" event is triggered on image elements (i.e. when we expect our onerror code in the image resizer client code to be triggered).
