### PR TITLE
Copy updates to site home page

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -13,14 +13,10 @@ bodyclass: home
         <p class="lead-mini">
             Mobify.js is an open source library for improving responsive sites
             by providing responsive images, JS/CSS optimization, Adaptive
-            Templating and more. Mobify.js also provides a 
-            "Capturing" API for manipulating the DOM before any resources have
-            loaded, giving developers the ability to enable the listed features above
-            without changing any backend markup.
-        </p>
+            Templating and more.</p>
+
         <p class="lead-mini">
-            Mobify.js powers millions
-            of daily mobile visits to your favourite websites.
+            Mobify.js also provides a <a href="https://hacks.mozilla.org/2013/03/capturing-improving-performance-of-the-adaptive-web/">Capturing</a> API for manipulating the DOM before any resources have loaded, giving developers the ability to enable the listed features above without changing any backend markup.
         </p>
         <div class="cta">
           <a href="/mobifyjs/v2/docs/" class="btn btn-primary rounded">Get Started Now</a>
@@ -48,7 +44,7 @@ bodyclass: home
         </div>
         <div class="span2"></div>
         <div class="span4 clients">
-            <h3>Mobify.js is used by:</h3>
+            <h3>Mobify.js powers millions of daily mobile visits</h3>
             <div class="well rounded shaded">
                 <span>Starbucks, Wired, Threadless, Siemens, GQ, Bosch</span>
             </div>
@@ -84,25 +80,22 @@ bodyclass: home
 </div>
 
 <div class="next-level">
-    <h2>Take it to the Next Level</h2>
+    <h2>Next Generation Performance</h2>
     <div class="row-fluid">
         <div class="span3 graphic">
             <span></span>
         </div>
         <div class="span5">
            <p>
-                Let the team who created Mobify.js help you take your finely-tuned
-                mobile site even further.
+                Let the team behind Mobify.js help you make your responsive site faster than it's ever been.
             </p>
            <p>
-                The Mobify Cloud offers a distributed CDN, mobile workflow
-                management, QA testing, automatic image resizing, smart JavaScript
-                optimization, and more.
+                Mobify Performance Suite is our suite of SAAS tools for automating performance improvements on your site.
             </p>
         </div>
         <div class="span4 cta">
-            <a href="https://cloud.mobify.com/"
-               class="btn btn-primary rounded">Try Mobify Cloud for Free</a>
+            <a href="https://cloud.mobify.com/mps/"
+               class="btn btn-primary rounded">Learn More</a>
         </div>
     </div><!-- .row-fluid -->
 </div><!-- .next-level -->


### PR DESCRIPTION
Linking to MozHack's capturing article, reflowing intro copy, and updating copy at the bottom of the page to talk about MPS.
