### PR TITLE
V2.0 backwards compat fixes

### DIFF
--- a/src/jazzcat.js
+++ b/src/jazzcat.js
@@ -21,7 +21,7 @@
  * into the cache using a bootloader request to Jazzcat. Scripts are then
  * executed directly from the cache.
  */
-define(["mobifyjs/utils", "mobifyjs/capture"], function(Utils, Capture) {
+define(["mobifyjs/utils"], function(Utils) {
     /**
      * An HTTP 1.1 compliant localStorage backed cache.
      */


### PR DESCRIPTION
**Status**: _Review_
**Reviewers**: @noahadams  @johnboxall 
**JIRA**: ???
**Linked PRs**: #244 
## Changes
- Adds a bunch of checks so that the tests that use Jazzcat.js in 1.1 don't break
- Backports an issue with Jazzcat for Firefox
## How to test-drive this PR
- Run the tests by running `node tests/server.js &` and navigating to http://127.0.0.1:1337/tests/index.html
## TODO
- Jazzcat in 2.0 is not designed to work with Adaptive Templating. This needs to work for both 1.1 and adaptive.js.
