### PR TITLE
V1.3 fix resize images shim

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,7 @@ install:
 	npm install
 
 test:
-	./tests/runner.sh
-
-jenkins:
-	./tests/runner.sh
+	grunt test
 
 all:
 	install

--- a/api/mobify-services.js
+++ b/api/mobify-services.js
@@ -1835,8 +1835,8 @@ require(["mobifyjs/utils", "mobifyjs/resizeImages", "mobifyjs/jazzcat"],
 
     // ResizeImages
     $.fn.resizeImages = function(opts) {
-        var imgs = this.find('img').toArray();
-        return ResizeImages.resize.call(window, imgs, opts);
+        var imgs = this.filter('img').add(this.find('img')).toArray();
+        return $(ResizeImages.resize.call(window, imgs, opts));
     };
     
     ResizeImages.defaults.projectName = Mobify.config.projectName || '';

--- a/api/mobify-services.js
+++ b/api/mobify-services.js
@@ -1812,10 +1812,12 @@ require(["mobifyjs/utils", "mobifyjs/resizeImages", "mobifyjs/jazzcat"],
         if (!this) {
             return $([]);
         }
+        var $scripts = this.filter('script').add(this.find('script'));
         opts = opts || {};
-        this.remove();
         opts.inlineLoader = false;
-        return $(Jazzcat.optimizeScripts.call(window, this, opts));
+        $scripts.remove();
+        var scripts = $scripts.toArray()
+        return $(Jazzcat.optimizeScripts.call(window, scripts, opts));
     };
     
     Jazzcat.defaults.projectName = (

--- a/tests/index.html
+++ b/tests/index.html
@@ -82,6 +82,10 @@
         <img x-src="http://www.mobify.com/i/phone-tablet.png" />
     </div>
 
+    <div id="resizeImages2">
+        <img x-src="http://www.mobify.com/i/phone-tablet.png" />
+    </div>
+
     <div id="resizeImages-non-http">
         <img x-src="gopher://archie.ftp.mailto/somanyprotocols" />
     </div>
@@ -527,7 +531,9 @@
 
         test('$.fn.resizeImages', function() {
             var $got = $('#resizeImages').resizeImages();
-            equal($got.length, 1);
+            equal($got.length, 1, "resizes image children");
+            $got = $('#resizeImages2 img').resizeImages()
+            equal($got.length, 1, "resizes images directly");
         });
 
         // Non-HTTP URLs should be unchanged.

--- a/vendor/mobify-service-clients/main.js
+++ b/vendor/mobify-service-clients/main.js
@@ -42,8 +42,8 @@ require(["mobifyjs/utils", "mobifyjs/resizeImages", "mobifyjs/jazzcat"],
 
     // ResizeImages
     $.fn.resizeImages = function(opts) {
-        var imgs = this.find('img').toArray();
-        return ResizeImages.resize.call(window, imgs, opts);
+        var imgs = this.filter('img').add(this.find('img')).toArray();
+        return $(ResizeImages.resize.call(window, imgs, opts));
     };
     
     ResizeImages.defaults.projectName = Mobify.config.projectName || '';

--- a/vendor/mobify-service-clients/main.js
+++ b/vendor/mobify-service-clients/main.js
@@ -19,10 +19,12 @@ require(["mobifyjs/utils", "mobifyjs/resizeImages", "mobifyjs/jazzcat"],
         if (!this) {
             return $([]);
         }
+        var $scripts = this.filter('script').add(this.find('script'));
         opts = opts || {};
-        this.remove();
         opts.inlineLoader = false;
-        return $(Jazzcat.optimizeScripts.call(window, this, opts));
+        $scripts.remove();
+        var scripts = $scripts.toArray()
+        return $(Jazzcat.optimizeScripts.call(window, scripts, opts));
     };
     
     Jazzcat.defaults.projectName = (


### PR DESCRIPTION
Status: **bug fix, merge quickly por favor**

Reviewers: **@jansepar**
## Changes
- Changes shim to properly filter and find `img` and `script` children when delegating to other API, and return proper `$()` wrapped results
## How to test-drive this PR
- Take a look at the tests/test changes
