### PR TITLE
v1.1: Don't lookup non-existent locales in i18n.

### DIFF
--- a/api/util.js
+++ b/api/util.js
@@ -21,7 +21,7 @@ Mobify.i18n = function(list, data) {
 
     var i18nlookup = function(key) {
         for(var i = 0; i < list.length; i++) {
-            var value = data[list[i]][key];
+            var value = (data[list[i]] ? data[list[i]][key] : undefined);
             if (value) return value;
        }
     }


### PR DESCRIPTION
Status: **Opened for visibility**

Reviewers: *\* @jansepar @rrjamie @noahadams **
## Changes
- Guard against looking up non-existent locales in the i18n function
## How to test-drive this PR
- Build yourself a mobify-client using this commit for mobify 1.1
- Create a project where you initialize an i18n module
- Add a locale to the i18n module which doesn't exist in the json source file
- Try looking up a key, it should return the value of that key under "DEFAULT" instead of erroring
