### PR TITLE
V1.1 project name v7 tag fix

### DIFF
--- a/api/config.js
+++ b/api/config.js
@@ -12,5 +12,11 @@
         config.configFile = Mobify.$('script[src*="mobify.js"]').first().attr('src') || '';
     }
     config.configDir = config.configFile.replace(/\/[^\/]*$/, '/');
+
+    // in the v6 tag, ajs is always defined, but that is not the case for v7 tags,
+    // and thus we will make it defined here.
+    if (Mobify && Mobify.config && Mobify.config.projectName) {
+        Mobify.ajs = Mobify.ajs || '//a.mobify.com/' + Mobify.config.projectName + 'a.js';
+    }
     config.ajs = Mobify.ajs;
 })();


### PR DESCRIPTION
Status: **Opened for visibility**

Reviewers: @tedtate @rrjamie 
JIRA: None
## Changes
- Makes sure Mobify.ajs is defined, even if the tag doesn't have it.
## How to test-drive this PR
- For a site that has a v7 tag, load a bundle and make sure Mobify.ajs is defined.
