### PR TITLE
Add warning for enterprise users about the tag

### DIFF
--- a/www/_includes/paid_warning.html
+++ b/www/_includes/paid_warning.html
@@ -1,0 +1,5 @@
+<div class="alert alert-block">
+    <p>If you have purchased a Mobify platform subscription, please head over to
+    <a href="https://cloud.mobify.com">cloud.mobify.com</a>
+    to get your tag instead.</p>
+</div>

--- a/www/docs/index.md
+++ b/www/docs/index.md
@@ -27,11 +27,7 @@ Mobify.js is a JavaScript framework for adapting websites for tablet and mobile.
 Insert the Mobify.js tag **immediately** after the opening _<head>_ tag on the
 website you want to adapt:
 
-<div class="alert alert-block">
-    <p>If you have purchased a Mobify platform subscription, please head over to
-    <a href="https://cloud.mobify.com">https://cloud.mobify.com</a>
-    to get your tag instead.</p>
-</div>
+{% include paid_warning.html %}
 
     <script>
     (function(window, document, mjs) {

--- a/www/docs/index.md
+++ b/www/docs/index.md
@@ -28,7 +28,7 @@ Insert the Mobify.js tag **immediately** after the opening _<head>_ tag on the
 website you want to adapt:
 
 <div class="alert alert-block">
-    <p>If you are a Mobify Enterprise customer, please head over to
+    <p>If you have purchased a Mobify platform subscription, please head over to
     <a href="https://cloud.mobify.com">https://cloud.mobify.com</a>
     to get your tag instead.</p>
 </div>

--- a/www/docs/index.md
+++ b/www/docs/index.md
@@ -27,6 +27,12 @@ Mobify.js is a JavaScript framework for adapting websites for tablet and mobile.
 Insert the Mobify.js tag **immediately** after the opening _<head>_ tag on the
 website you want to adapt:
 
+<div class="alert alert-block">
+    <p>If you are a Mobify Enterprise customer, please head over to
+    <a href="https://cloud.mobify.com">https://cloud.mobify.com</a>
+    to get your tag instead.</p>
+</div>
+
     <script>
     (function(window, document, mjs) {
 

--- a/www/v2/docs/index.md
+++ b/www/v2/docs/index.md
@@ -34,7 +34,7 @@ any element that loads external resources!**):
 [Unminified version on Github](https://github.com/mobify/mobifyjs/blob/v2.0/tag/bootstrap.html){: target='_blank' }
 
 <div class="alert alert-block">
-    <p>If you are a Mobify Enterprise customer, please head over to
+    <p>If you have purchased a Mobify platform subscription, please head over to
     <a href="https://cloud.mobify.com">https://cloud.mobify.com</a>
     to get your tag instead.</p>
 </div>
@@ -77,7 +77,7 @@ Then, paste the following tag before <code>&lt;/head&gt;</code>, or top of
 <code>&lt;body&gt;</code>:
 
 <div class="alert alert-block">
-    <p>If you are a Mobify Enterprise customer, please head over to
+    <p>If you have purchased a Mobify platform subscription, please head over to
     <a href="https://cloud.mobify.com">https://cloud.mobify.com</a>
     to get your tag instead.</p>
 </div>

--- a/www/v2/docs/index.md
+++ b/www/v2/docs/index.md
@@ -33,6 +33,12 @@ be placed after the opening <code>&lt;head&gt;</code> tag (**must be placed abov
 any element that loads external resources!**):
 [Unminified version on Github](https://github.com/mobify/mobifyjs/blob/v2.0/tag/bootstrap.html){: target='_blank' }
 
+<div class="alert alert-block">
+    <p>If you are a Mobify Enterprise customer, please head over to
+    <a href="https://cloud.mobify.com">https://cloud.mobify.com</a>
+    to get your tag instead.</p>
+</div>
+
     <script>!function(a,b,c,d,e){function g(a,c,d,e){var f=b.getElementsByTagName("script")[0];a.src=e,a.id=c,a.setAttribute("class",d),f.parentNode.insertBefore(a,f)}a.Mobify={points:[+new Date]};var f=/((; )|#|&|^)mobify=(\d)/.exec(location.hash+"; "+b.cookie);if(f&&f[3]){if(!+f[3])return}else if(!c())return;b.write('<plaintext style="display:none">'),setTimeout(function(){var c=a.Mobify=a.Mobify||{};c.capturing=!0;var f=b.createElement("script"),h="mobify",i=function(){var c=new Date;c.setTime(c.getTime()+3e5),b.cookie="mobify=0; expires="+c.toGMTString()+"; path=/",a.location=a.location.href};f.onload=function(){if(e)if("string"==typeof e){var c=b.createElement("script");c.onerror=i,g(c,"main-executable",h,mainUrl)}else a.Mobify.mainExecutable=e.toString(),e()},f.onerror=i,g(f,"mobify-js",h,d)})}(window,document,function(){a=/webkit|(firefox)[\/\s](\d+)|(opera)[\s\S]*version[\/\s](\d+)|(trident)[\/\s](\d+)/i.exec(navigator.userAgent);return!a||a[1]&&4>+a[2]||a[3]&&11>+a[4]||a[5]&&6>+a[6]?!1:!0},
 
     // path to mobify.js
@@ -69,6 +75,12 @@ the DOM is ready.
 
 Then, paste the following tag before <code>&lt;/head&gt;</code>, or top of
 <code>&lt;body&gt;</code>:
+
+<div class="alert alert-block">
+    <p>If you are a Mobify Enterprise customer, please head over to
+    <a href="https://cloud.mobify.com">https://cloud.mobify.com</a>
+    to get your tag instead.</p>
+</div>
 
     <script async src="//cdn.mobify.com/mobifyjs/build/mobify-2.0.11.min.js"></script>
     <script>

--- a/www/v2/docs/index.md
+++ b/www/v2/docs/index.md
@@ -33,11 +33,7 @@ be placed after the opening <code>&lt;head&gt;</code> tag (**must be placed abov
 any element that loads external resources!**):
 [Unminified version on Github](https://github.com/mobify/mobifyjs/blob/v2.0/tag/bootstrap.html){: target='_blank' }
 
-<div class="alert alert-block">
-    <p>If you have purchased a Mobify platform subscription, please head over to
-    <a href="https://cloud.mobify.com">https://cloud.mobify.com</a>
-    to get your tag instead.</p>
-</div>
+{% include paid_warning.html %}
 
     <script>!function(a,b,c,d,e){function g(a,c,d,e){var f=b.getElementsByTagName("script")[0];a.src=e,a.id=c,a.setAttribute("class",d),f.parentNode.insertBefore(a,f)}a.Mobify={points:[+new Date]};var f=/((; )|#|&|^)mobify=(\d)/.exec(location.hash+"; "+b.cookie);if(f&&f[3]){if(!+f[3])return}else if(!c())return;b.write('<plaintext style="display:none">'),setTimeout(function(){var c=a.Mobify=a.Mobify||{};c.capturing=!0;var f=b.createElement("script"),h="mobify",i=function(){var c=new Date;c.setTime(c.getTime()+3e5),b.cookie="mobify=0; expires="+c.toGMTString()+"; path=/",a.location=a.location.href};f.onload=function(){if(e)if("string"==typeof e){var c=b.createElement("script");c.onerror=i,g(c,"main-executable",h,mainUrl)}else a.Mobify.mainExecutable=e.toString(),e()},f.onerror=i,g(f,"mobify-js",h,d)})}(window,document,function(){a=/webkit|(firefox)[\/\s](\d+)|(opera)[\s\S]*version[\/\s](\d+)|(trident)[\/\s](\d+)/i.exec(navigator.userAgent);return!a||a[1]&&4>+a[2]||a[3]&&11>+a[4]||a[5]&&6>+a[6]?!1:!0},
 
@@ -76,11 +72,7 @@ the DOM is ready.
 Then, paste the following tag before <code>&lt;/head&gt;</code>, or top of
 <code>&lt;body&gt;</code>:
 
-<div class="alert alert-block">
-    <p>If you have purchased a Mobify platform subscription, please head over to
-    <a href="https://cloud.mobify.com">https://cloud.mobify.com</a>
-    to get your tag instead.</p>
-</div>
+{% include paid_warning.html %}
 
     <script async src="//cdn.mobify.com/mobifyjs/build/mobify-2.0.11.min.js"></script>
     <script>


### PR DESCRIPTION
Status: **Opened for review**

Reviewers: @johnboxall 
## Changes
- Add warning for enterprise users to get their tag from cloud.mobify.com
## How to test-drive this PR
- Run `grunt jekyll`
- Navigate to http://localhost:4000/mobifyjs/v2/docs/ and http://localhost:4000/mobifyjs/docs/ to see the warnings.
