### PR TITLE
V1.1.1 - ADJS-87: Fix double mobify-path cookie

### DIFF
--- a/api/combo.js
+++ b/api/combo.js
@@ -275,9 +275,12 @@ var $ = Mobify.$
   , defaults = combineScripts.defaults = {
         selector: 'script'
       , attribute: 'x-src'
-      , endpoint: '//jazzcat.mobify.com/jsonp/'
+      , proto: '//'
+      , host: 'jazzcat.mobify.com'
+      , endpoint: 'jsonp'
       , execCallback: 'Mobify.combo.exec'
       , loadCallback: 'Mobify.combo.load'
+      , projectName: Mobify.config.projectName || ''
     }
 
   , combo = Mobify.combo = {
@@ -353,8 +356,11 @@ var $ = Mobify.$
      * Returns a URL suitable for use with the combo service. Sorted to generate
      * consistent URLs.
      */
-  , getURL = function(urls, callback) {
-        return defaults.endpoint + callback + '/' + JSONURIencode(urls.slice().sort());
+  , getURL = Mobify.combo.getURL = function(urls, callback) {
+        return defaults.proto + defaults.host + 
+          (defaults.projectName ? '/project-' + defaults.projectName : '') + 
+          '/' + defaults.endpoint + '/' + callback + '/' +
+          JSONURIencode(urls.slice().sort());
     }
 
   , JSONURIencode = Mobify.JSONURIencode = function(obj) {
@@ -365,8 +371,11 @@ $.fn.combineScripts = function(opts) {
     return combineScripts.call(window, this, opts)
 }
 
+// expose defaults for testing
+$.fn.combineScripts.defaults = combineScripts.defaults;
+
 Mobify.cssURL = function(obj) {
-    return '//combo.mobify.com/css/' + JSONURIencode(obj)
+    return '//jazzcat.mobify.com/css/' + JSONURIencode(obj)
 }
 
 })(this, document, Mobify);

--- a/api/combo.js
+++ b/api/combo.js
@@ -288,7 +288,7 @@ var $ = Mobify.$
          * `document.write`. Prefer loading contents from cache.
          */
         exec: function(url, forceDataURI) {
-            var resource, safeSource;
+            var resource, safeSource, dataURI;
 
             if (resource = httpCache.get(url, true)) {
                 if (resource.text && !forceDataURI) {
@@ -318,13 +318,14 @@ var $ = Mobify.$
                     safeSource = resource.body.replace(/(<\/scr)(ipt\s*>)/ig, '$1\\$2');
                     return document.write('<script data-orig-src="' + url + '">' + safeSource + '<\/scr'+'ipt>');
                 } else {
-                    url = httpCache.utils.dataURI(resource);
+                    dataURI = httpCache.utils.dataURI(resource);
+                    return document.write('<script data-orig-src="' + url + '" src="' + dataURI + '"><\/scr' + 'ipt>');  
                 }
+            } else {
+                // Firefox will choke on closing script tags passed through
+                // the ark.
+                document.write('<script src="' + url + '"><\/scr' + 'ipt>');              
             }
-            
-            // Firefox will choke on closing script tags passed through
-            // the ark.
-            document.write('<script src="' + url + '"><\/scr' + 'ipt>');
         }
 
         /**

--- a/api/combo.js
+++ b/api/combo.js
@@ -280,7 +280,6 @@ var $ = Mobify.$
       , endpoint: 'jsonp'
       , execCallback: 'Mobify.combo.exec'
       , loadCallback: 'Mobify.combo.load'
-      , projectName: Mobify.config.projectName || ''
     }
 
   , combo = Mobify.combo = {
@@ -359,8 +358,9 @@ var $ = Mobify.$
      * consistent URLs.
      */
   , getURL = Mobify.combo.getURL = function(urls, callback) {
+        var projectName = Mobify.config.projectName || '';
         return defaults.proto + defaults.host + 
-          (defaults.projectName ? '/project-' + defaults.projectName : '') + 
+          (projectName ? '/project-' + projectName : '') + 
           '/' + defaults.endpoint + '/' + callback + '/' +
           JSONURIencode(urls.slice().sort());
     }

--- a/api/combo.js
+++ b/api/combo.js
@@ -281,6 +281,8 @@ var $ = Mobify.$
     }
 
   , combo = Mobify.combo = {
+        // a copy of document.write in case it is reassigned by other scripts
+        _docWrite: document.write,
         /**
          * Emit a <script> tag to execute the contents of `url` using
          * `document.write`. Prefer loading contents from cache.
@@ -323,7 +325,7 @@ var $ = Mobify.$
                 }
             }
 
-            document.write('<script ' + out + '<\/script>');
+            Mobify.combo._docWrite.call(document, '<script ' + out + '<\/script>');
         }
 
         /**

--- a/api/combo.js
+++ b/api/combo.js
@@ -355,7 +355,10 @@ var $ = Mobify.$
                 }
             }
 
-            Mobify.combo._docWrite.call(document, '<script ' + out + '<\/script>');
+            // TT: Uglify will strip out the escape here, so we need to split up
+            //    '<' and '/' to prevent browsers from barfing when attempting to document.write
+            //    this out.
+            Mobify.combo._docWrite.call(document, '<script ' + out + '<' +' \/script>');
         }
 
         /**

--- a/api/combo.js
+++ b/api/combo.js
@@ -355,10 +355,10 @@ var $ = Mobify.$
                 }
             }
 
-            // TT: Uglify will strip out the escape here, so we need to split up
-            //    '<' and '/' to prevent browsers from barfing when attempting to document.write
-            //    this out.
-            Mobify.combo._docWrite.call(document, '<script ' + out + '<' +' \/script>');
+            // Uglify will strip out the escape here, so we need to split up
+            // '<' and '/' to prevent browsers (Firefox in this case) 
+            // from barfing when attempting to document.write this out.
+            Mobify.combo._docWrite.call(document, '<script ' + out + '<' + '/script>');
         }
 
         /**

--- a/api/combo.js
+++ b/api/combo.js
@@ -190,9 +190,9 @@ var ccDirectives = /^\s*(public|private|no-cache|no-store)\s*$/
               , expires;
 
               // Fresh if less than 10 minutes old
-              if (date && (now < date + 600 * 1000)) {
-                    return false;
-              }
+            if (date && (now < date + 600 * 1000)) {
+               return false;
+            }
 
             // If `max-age` and `date` are present, and no other cache
             // directives exist, then we are stale if we are older.

--- a/api/config.js
+++ b/api/config.js
@@ -12,5 +12,11 @@
         config.configFile = Mobify.$('script[src*="mobify.js"]').first().attr('src') || '';
     }
     config.configDir = config.configFile.replace(/\/[^\/]*$/, '/');
+
+    // in the v6 tag, ajs is always defined, but that is not the case for v7 tags,
+    // and thus we will make it defined here.
+    if (Mobify && Mobify.config && Mobify.config.projectName) {
+        Mobify.ajs = Mobify.ajs || '//a.mobify.com/' + Mobify.config.projectName + 'a.js';
+    }
     config.ajs = Mobify.ajs;
 })();

--- a/api/cont.js
+++ b/api/cont.js
@@ -231,11 +231,6 @@
 
                 if (args.length == 1) data = cont.all();
                 dust.render(template, base.push(data), function(err, out) {
-                    // Apply scroll fix to iOS 8.0
-                    if (out && Mobify.isIOS8_0()) {
-                        out = Mobify.ios8_0ScrollFix(out);
-                    }
-
                     if (err) {
                         async.finish(out);
                         Mobify.console.die(err);

--- a/api/cont.js
+++ b/api/cont.js
@@ -231,6 +231,11 @@
 
                 if (args.length == 1) data = cont.all();
                 dust.render(template, base.push(data), function(err, out) {
+                    // Apply scroll fix to iOS 8.0
+                    if (out && Mobify.isIOS8_0()) {
+                        out = Mobify.ios8_0ScrollFix(out);
+                    }
+
                     if (err) {
                         async.finish(out);
                         Mobify.console.die(err);

--- a/api/extractDOM.js
+++ b/api/extractDOM.js
@@ -73,9 +73,9 @@ $.extend(html, {
     // 1. Get the original markup from the document.
     // 2. Disable the markup.
     // 3. Construct the source pseudoDOM.
-    extractDOM: function() {
+    extractDOM: function(doc) {
         // Extract escaped markup out of the DOM
-        var captured = guillotine(html.extractHTML());
+        var captured = guillotine(html.extractHTML(doc));
 
         Mobify.timing.addPoint('Recovered Markup');
 

--- a/api/main.js
+++ b/api/main.js
@@ -107,13 +107,8 @@ $.extend(Mobify.transform, {
         };
 
         if (Mobify.isIOS8_0()){
-            // See `utils.js` for more information about this fix.
-            Mobify.ios8_0ScrollFix(document);
-            window.requestAnimationFrame(function(){
-                window.requestAnimationFrame(function(){
-                    write();
-                })
-            })
+            // See `util.js` for more information about this fix.
+            Mobify.ios8_0ScrollFix(document, write);
         } else {
             write();
         }

--- a/api/main.js
+++ b/api/main.js
@@ -92,6 +92,11 @@ $.extend(Mobify.transform, {
             timing.logPoints();
         }
 
+        if (Mobify.isIOS8_0()){
+            // See `utils.js` for more information about this fix.
+            Mobify.ios8_0ScrollFix(document);
+        }
+
         // We'll write markup a tick later, as Firefox logging is async
         // and gets interrupted if followed by synchronous document.open
         window.setTimeout(function(){

--- a/api/main.js
+++ b/api/main.js
@@ -92,22 +92,31 @@ $.extend(Mobify.transform, {
             timing.logPoints();
         }
 
+        var write = function(){
+            // We'll write markup a tick later, as Firefox logging is async
+            // and gets interrupted if followed by synchronous document.open
+            window.setTimeout(function(){
+                // `document.open` clears events bound to `document`.
+                document.open();
+
+                // In Webkit, `document.write` immediately executes inline scripts 
+                // not preceded by an external resource.
+                document.write(markup);
+                document.close();
+            });
+        };
+
         if (Mobify.isIOS8_0()){
             // See `utils.js` for more information about this fix.
             Mobify.ios8_0ScrollFix(document);
+            window.requestAnimationFrame(function(){
+                window.requestAnimationFrame(function(){
+                    write();
+                })
+            })
+        } else {
+            write();
         }
-
-        // We'll write markup a tick later, as Firefox logging is async
-        // and gets interrupted if followed by synchronous document.open
-        window.setTimeout(function(){
-            // `document.open` clears events bound to `document`.
-            document.open();
-
-            // In Webkit, `document.write` immediately executes inline scripts 
-            // not preceded by an external resource.
-            document.write(markup);
-            document.close();
-        });
     },
 
     // Kickstart processing. Guard against beginning before the document is ready.

--- a/api/main.js
+++ b/api/main.js
@@ -92,10 +92,10 @@ $.extend(Mobify.transform, {
             timing.logPoints();
         }
 
-        var write = function(){
+        var write = function() {
             // We'll write markup a tick later, as Firefox logging is async
             // and gets interrupted if followed by synchronous document.open
-            window.setTimeout(function(){
+            window.setTimeout(function() {
                 // `document.open` clears events bound to `document`.
                 document.open();
 
@@ -106,7 +106,7 @@ $.extend(Mobify.transform, {
             });
         };
 
-        if (Mobify.isIOS8_0()){
+        if (Mobify.isIOS8_0()) {
             // See `util.js` for more information about this fix.
             Mobify.ios8_0ScrollFix(document, write);
         } else {

--- a/api/util.js
+++ b/api/util.js
@@ -29,7 +29,7 @@ Mobify.i18n = function(list, data) {
 };
 
 Mobify.isIOS8_0 = function() {
-    var IOS8_REGEX = /ip(hone|od|ad).*OS 8_0/i;
+    var IOS8_REGEX = /ip(hone|od|ad).*Version\/8.0/i;
 
     return IOS8_REGEX.test(window.navigator.userAgent);
 };

--- a/api/util.js
+++ b/api/util.js
@@ -64,10 +64,17 @@ Mobify.ios8_0ScrollFix = function(doc, callback) {
     head.appendChild(meta);
 
     if (callback) {
-        // Wait two paints for the meta tag to take effect.
-        window.requestAnimationFrame(function() {
-            window.requestAnimationFrame(callback);
-        });
+        // Wait two paints for the meta viewport tag to take effect. This is
+        // required for this fix to work, but guard against it being undefined
+        // anyway just in case.
+        if (window.requestAnimationFrame) {
+            window.requestAnimationFrame(function() {
+                window.requestAnimationFrame(callback);
+            });
+        }
+        else {
+            callback();
+        }
     }
 };
 

--- a/api/util.js
+++ b/api/util.js
@@ -40,22 +40,28 @@ Mobify.isIOS8_0 = function() {
  * capturing, the initial document never has an active meta viewport tag.
  * Then, the rendered document injects one causing the aforementioned scroll.
  *
- * Create a meta viewport tag that we inject into the page to force the
- * page to scroll before anything is rendered in the page
- * (this code should be called before document.open!)
+ * Create a meta viewport tag that we inject into the page to force the page to
+ * scroll before anything is rendered in the page (this code should be called
+ * before document.open!)
  *
  * JIRA: https://mobify.atlassian.net/browse/GOLD-883
  * Open Radar: http://www.openradar.me/radar?id=5516452639539200
  * WebKit Bugzilla: https://bugs.webkit.org/show_bug.cgi?id=136904
  */
 Mobify.ios8_0ScrollFix = function(doc, callback) {
+    // Using `getElementsByTagName` here because grabbing head using
+    // `document.head` will throw exceptions in some older browsers (iOS 4.3).
+    var head = doc.getElementsByTagName('head');
+    // Be extra safe and guard against `head` not existing.
+    if (!head.length) {
+        return;
+    }
+    var head = head[0];
+
     var meta = document.createElement('meta');
     meta.setAttribute('name', 'viewport');
     meta.setAttribute('content', 'width=device-width');
-    // Using `getElementsByTagName` here because grabbing head using
-    // document.head will throw exceptions in some older browsers
-    // (iOS 4.3).
-    doc.getElementsByTagName('head')[0].appendChild(meta);
+    head.appendChild(meta);
 
     if (callback) {
         // Wait two paints for the meta tag to take effect.

--- a/api/util.js
+++ b/api/util.js
@@ -48,7 +48,7 @@ Mobify.isIOS8_0 = function() {
  * Open Radar: http://www.openradar.me/radar?id=5516452639539200
  * WebKit Bugzilla: https://bugs.webkit.org/show_bug.cgi?id=136904
  */
-Mobify.ios8_0ScrollFix = function(doc) {
+Mobify.ios8_0ScrollFix = function(doc, callback) {
     var meta = document.createElement('meta');
     meta.setAttribute('name', 'viewport');
     meta.setAttribute('content', 'width=device-width');
@@ -56,6 +56,13 @@ Mobify.ios8_0ScrollFix = function(doc) {
     // document.head will throw exceptions in some older browsers
     // (iOS 4.3).
     doc.getElementsByTagName('head')[0].appendChild(meta);
+
+    if (callback) {
+        // Wait two paints for the meta tag to take effect.
+        window.requestAnimationFrame(function() {
+            window.requestAnimationFrame(callback);
+        });
+    }
 };
 
 })(Mobify.$, Mobify);

--- a/api/util.js
+++ b/api/util.js
@@ -21,7 +21,7 @@ Mobify.i18n = function(list, data) {
 
     var i18nlookup = function(key) {
         for(var i = 0; i < list.length; i++) {
-            var value = data[list[i]][key];
+            var value = (data[list[i]] ? data[list[i]][key] : undefined);
             if (value) return value;
        }
     }

--- a/api/util.js
+++ b/api/util.js
@@ -48,46 +48,17 @@ Mobify.isIOS8_0 = function() {
  * Open Radar: http://www.openradar.me/radar?id=5516452639539200
  * WebKit Bugzilla: https://bugs.webkit.org/show_bug.cgi?id=136904
  */
-Mobify.ios8_0ScrollFix = function(htmlString) {
-    var BODY_REGEX = /<body(?:[^>'"]*|'[^']*?'|"[^"]*?")*>/i;
-
-    var openingBodyTag = BODY_REGEX.exec(htmlString);
-    // Do nothing if we can't find an opening `body` tag.
-    if (!openingBodyTag) {
-        return htmlString;
-    }
-    openingBodyTag = openingBodyTag[0];
-
-    // Use DOM methods to manipulate the attributes on the `body` tag. This
-    // lets us rely on the browser to set body's style to `display: none`.
-    // We create a containing element to be able to set an inner HTML string.
-    var divEl = document.createElement('div');
-    
-    // The `div`'s inner string can't be a `body` tag, so we temporarily change
-    // it to a `div`..
-    var openingBodyTagAsDiv = openingBodyTag.replace(/^<body/, '<div');
-    divEl.innerHTML = openingBodyTagAsDiv;
-
-    // ..so that we can set it to be hidden..
-    divEl.firstChild.style.display = 'none';
-
-    // ..and change it back to a `body` string!
-    openingBodyTagAsDiv = divEl.innerHTML.replace(/<\/div>$/, '');
-    openingBodyTag = openingBodyTagAsDiv.replace(/^<div/, '<body');
-
-    // Append the script to show the body after two paints. This needs to be
-    // inside the body to ensure that `document.body` is available when it
-    // executes.
-    var script =
-        "<script>" +
-        "  window.requestAnimationFrame(function() {" +
-        "    window.requestAnimationFrame(function() {" +
-        "      document.body.style.display = '';" +
-        "    });" +
-        "  });" +
-        "<\/script>";
-
-    return htmlString.replace(BODY_REGEX, openingBodyTag + script);
+Mobify.ios8_0ScrollFix = function(doc) {
+    // Create a meta viewport tag that we inject into the page to force the
+    // page to scroll before anything is rendered in the page
+    // (this code should be called before document.open!)
+    var meta = document.createElement('meta');
+    meta.setAttribute('name', 'viewport');
+    meta.setAttribute('content', 'width=device-width');
+    // Using `getElementsByTagName` here because grabbing head using
+    // document.head will throw exceptions in some older browsers
+    // (iOS 4.3).
+    doc.getElementsByTagName('head')[0].appendChild(meta);
 };
 
 })(Mobify.$, Mobify);

--- a/api/util.js
+++ b/api/util.js
@@ -40,18 +40,15 @@ Mobify.isIOS8_0 = function() {
  * capturing, the initial document never has an active meta viewport tag.
  * Then, the rendered document injects one causing the aforementioned scroll.
  *
- * This patches HTML to hide the body until the first paint (and hopefully after
- * the initial viewport is calculated). By the time we show the body the new
- * viewport should have already taken effect.
+ * Create a meta viewport tag that we inject into the page to force the
+ * page to scroll before anything is rendered in the page
+ * (this code should be called before document.open!)
  *
  * JIRA: https://mobify.atlassian.net/browse/GOLD-883
  * Open Radar: http://www.openradar.me/radar?id=5516452639539200
  * WebKit Bugzilla: https://bugs.webkit.org/show_bug.cgi?id=136904
  */
 Mobify.ios8_0ScrollFix = function(doc) {
-    // Create a meta viewport tag that we inject into the page to force the
-    // page to scroll before anything is rendered in the page
-    // (this code should be called before document.open!)
     var meta = document.createElement('meta');
     meta.setAttribute('name', 'viewport');
     meta.setAttribute('content', 'width=device-width');

--- a/api/util.js
+++ b/api/util.js
@@ -28,4 +28,66 @@ Mobify.i18n = function(list, data) {
     return i18nlookup;
 };
 
+Mobify.isIOS8_0 = function() {
+    var IOS8_REGEX = /ip(hone|od|ad).*OS 8_0/i;
+
+    return IOS8_REGEX.test(window.navigator.userAgent);
+};
+
+/**
+ * iOS 8.0 has a bug where dynamically switching the viewport (by swapping the
+ * viewport meta tag) causes the viewport to automatically scroll. When
+ * capturing, the initial document never has an active meta viewport tag.
+ * Then, the rendered document injects one causing the aforementioned scroll.
+ *
+ * This patches HTML to hide the body until the first paint (and hopefully after
+ * the initial viewport is calculated). By the time we show the body the new
+ * viewport should have already taken effect.
+ *
+ * JIRA: https://mobify.atlassian.net/browse/GOLD-883
+ * Open Radar: http://www.openradar.me/radar?id=5516452639539200
+ * WebKit Bugzilla: https://bugs.webkit.org/show_bug.cgi?id=136904
+ */
+Mobify.ios8_0ScrollFix = function(htmlString) {
+    var BODY_REGEX = /<body(?:[^>'"]*|'[^']*?'|"[^"]*?")*>/i;
+
+    var openingBodyTag = BODY_REGEX.exec(htmlString);
+    // Do nothing if we can't find an opening `body` tag.
+    if (!openingBodyTag) {
+        return htmlString;
+    }
+    openingBodyTag = openingBodyTag[0];
+
+    // Use DOM methods to manipulate the attributes on the `body` tag. This
+    // lets us rely on the browser to set body's style to `display: none`.
+    // We create a containing element to be able to set an inner HTML string.
+    var divEl = document.createElement('div');
+    
+    // The `div`'s inner string can't be a `body` tag, so we temporarily change
+    // it to a `div`..
+    var openingBodyTagAsDiv = openingBodyTag.replace(/^<body/, '<div');
+    divEl.innerHTML = openingBodyTagAsDiv;
+
+    // ..so that we can set it to be hidden..
+    divEl.firstChild.style.display = 'none';
+
+    // ..and change it back to a `body` string!
+    openingBodyTagAsDiv = divEl.innerHTML.replace(/<\/div>$/, '');
+    openingBodyTag = openingBodyTagAsDiv.replace(/^<div/, '<body');
+
+    // Append the script to show the body after two paints. This needs to be
+    // inside the body to ensure that `document.body` is available when it
+    // executes.
+    var script =
+        "<script>" +
+        "  window.requestAnimationFrame(function() {" +
+        "    window.requestAnimationFrame(function() {" +
+        "      document.body.style.display = '';" +
+        "    });" +
+        "  });" +
+        "<\/script>";
+
+    return htmlString.replace(BODY_REGEX, openingBodyTag + script);
+};
+
 })(Mobify.$, Mobify);

--- a/konf/base.konf
+++ b/konf/base.konf
@@ -28,7 +28,6 @@
     {>"/base/api/util.js"/}
 {/lib_export}
 
-{>"/base/api/persistHash.js"/}
 {>"/base/api/logging.js"/}
 {>"/base/api/timing.js"/}
 {>"/base/api/externals.js"/}

--- a/tests/fixtures/plaintext-sibbling-forms.html
+++ b/tests/fixtures/plaintext-sibbling-forms.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <script>
+        // Simulate mobify
+        document.write("<plaintext style=\"display:none\">");
+    </script>
+</head>
+<body>
+    <form></form>
+    <form></form>
+</body>
+</html>

--- a/tests/index.html
+++ b/tests/index.html
@@ -156,13 +156,15 @@
         var $ = Mobify.$
           , httpCache = Mobify.httpCache
             // Time offsets in seconds
-          , TWO_WEEKS = 14 * 24 * 60 * 60
+          , ONE_WEEK = 7 * 24 * 60 * 60
+          , TWO_WEEKS = 2 * ONE_WEEK
           , TEN_MINUTES = 600
-          , UTC_TWO_WEEKS_FROM_NOW = (new Date(Date.now() + (TWO_WEEKS * 1000))).toUTCString()
             // UTC dates
           , UTC_TWO_WEEKS_FROM_NOW = (new Date(Date.now() + (TWO_WEEKS * 1000))).toUTCString()
           , UTC_TWO_WEEKS_AGO = (new Date(Date.now() - (TWO_WEEKS * 1000))).toUTCString()
+          , UTC_ONE_WEEK_AGO = (new Date(Date.now() - (ONE_WEEK * 1000))).toUTCString()
           , UTC_NOW = (new Date()).toUTCString()
+          , UTC_TWELVE_HOURS_AGO = (new Date(Date.now() - (12 * 60 * 60 * 1000))).toUTCString()
 
             // I don't fit in `localStorage` in Chrome or Safari...
             // But I do seem to fit in FF.
@@ -190,7 +192,7 @@
                 return document.implementation.createDocument(ns, 'html', null)
             }
 
-        module('combo')
+        module('combo');
 
         test('Mobify.cssURL - It exists', function() {
             ok(Mobify.cssURL({}));
@@ -458,7 +460,7 @@
                 });
             });
 
-        test('httpCache.utils.isStale', 9, function() {
+        test('httpCache.utils.isStale', 10, function() {
             var isStale = httpCache.utils.isStale
               , resources = {
                     'stale-expires': {
@@ -510,6 +512,12 @@
                         'date': UTC_NOW
                     }
                 }
+                , 'fresh-by-10-percent-heuristic': {
+                    'headers': {
+                        'date': UTC_TWELVE_HOURS_AGO
+                      , 'last-modified': UTC_TWO_WEEKS_AGO
+                    }
+                }
             };
         
 
@@ -523,6 +531,8 @@
             ok(isStale(resources['invalid-expires']), 'Invalid expires is stale');
             // Test our ten minute minimum
             ok(!isStale(resources['new-no-cache-headers']), 'No cache headers but less than 10 minutes old');
+            // Test ten percent heuristic
+            ok(!isStale(resources['fresh-by-10-percent-heuristic']), 'No cache headers but fresh by last modified 10% heuristic');
 
         });
 

--- a/tests/index.html
+++ b/tests/index.html
@@ -556,29 +556,23 @@
 
         module('util');
 
-        test("Mobify.ios8_0ScrollFix", function() {
-            var html =
-                "<html>" +
-                "<head>" +
-                "  <title>Scroll Fix Test</title>" +
-                "</head>" +
-                "<body style='font-size: 13px' class='x-test'>" +
-                "  <ul>" +
-                "    <li>Woohoo</li>" +
-                "  </ul>" +
-                "</body>" +
-                "</html>";
+        asyncTest("Mobify.ios8_0ScrollFix", function() {
+            var html = document.createElement('html');
+            var head = document.createElement('head');
+            html.appendChild(head);
 
-            html = Mobify.ios8_0ScrollFix(html);
-            
-            ok(html.indexOf('font-size: 13px') !== -1,
-                '`font-size: 13px` on the body tag is still present');
-            ok(html.indexOf('display: none') !== -1,
-                '`display: none` was set on the body tag');
-            ok(html.indexOf("document.body.style.display = '';") !== -1,
-                'there is a script to show the body');
-            ok(html.indexOf('x-test') !== -1,
-                '`x-test` body class tag is still present');
+            Mobify.ios8_0ScrollFix(html, function() {
+                var meta = html.getElementsByTagName('meta')[0]
+
+                ok(true,
+                    'meta tag is appended');
+                ok(meta.getAttribute('name'), 'viewport',
+                    'meta name is viewport');
+                ok(meta.getAttribute('content'), 'width=device-width',
+                    'content is width=device-width');
+
+                start();
+            });
         });
 
         module('resizeImages');

--- a/tests/index.html
+++ b/tests/index.html
@@ -744,6 +744,30 @@
             ok(got, "makeElement fails to get attributes of badly formed 'bodyclass' element");
         });
 
+        // There is a bug on iOS 8.0 where:
+        //     `body`.innerHTML = '<form></form><form></form>';
+        // produces the following elements:
+        //     `<form><form></form></form>`
+        //
+        // This test ensures that capturing works as expected.
+        //
+        asyncTest('Mobify.html.extractDOM correctly extracts document with two sibbling forms', function() {
+            var $iframe = $('<iframe src="/tests/fixtures/plaintext-sibbling-forms.html">');
+
+            $iframe.one('load', function() {
+                var doc = $iframe.get(0).contentDocument;
+                var result = Mobify.html.extractDOM(doc);
+                var children = result.$body.children();
+
+                equal(children.length, 2, 'extracted body has two children');
+                equal(children[0].nodeName, 'FORM', 'first child element is a form');
+                equal(children[1].nodeName, 'FORM', 'second child element is a form');
+
+                start();
+            });
+            $('body').append($iframe);
+        });
+
         module('Mobify.urlmatch');
         // First, some utility functions and variables
         var locationify, urlmatch, testUrlMatch;

--- a/tests/index.html
+++ b/tests/index.html
@@ -142,6 +142,12 @@
     <iframe id="test-unmobify" src="fixtures/unmobify-basic.html"></iframe>
     <a href="fixtures-unmobify/basic.html">BASIC</a>
 
+    <script id="test-mobify-combo-exec" type="text/test">
+/*<\/script>*/
+"<\/script>"
+/<\/script>/
+    </script>
+
     <script>
         var $ = Mobify.$
           , httpCache = Mobify.httpCache
@@ -296,6 +302,51 @@
                 ok(httpCache.get(encodeURI(url)) != undefined, "Missing resource.");
                 start();
             });
+        });
+
+        test('Mobify.combo.exec', 5, function() {
+            var cache = {
+                'cached': {
+                    'headers': {'expires': UTC_TWO_WEEKS_FROM_NOW},
+                    'status': 'ready',
+                    'url': 'cached',
+                    'body': 'cached',
+                    'text': true
+                },
+                'cached-with-scripts': {
+                    'headers': {'expires': UTC_TWO_WEEKS_FROM_NOW},
+                    'status': 'ready',
+                    'url': 'cached-with-scripts',
+                    'body': getText("#test-mobify-combo-exec"),
+                    'text': true
+                }
+            };
+
+            httpCache.reset(cache);
+
+            var nativeDocumentWrite = document.write
+            document.write = function(s) {
+                wrote = s
+            }
+
+            try {
+                Mobify.combo.exec('cached');
+                equal(wrote, '<script data-orig-src="cached">cached<\/script>');
+
+                Mobify.combo.exec('uncached');
+                equal(wrote, '<script src="uncached"><\/script>');
+
+                Mobify.combo.exec('cached-with-scripts');
+                equal(wrote, '<script data-orig-src=\"cached-with-scripts\">/*<\/scr\\ipt>*/ \"<\/scr\\ipt>\" \/<\/scr\\ipt>\/<\/script>');
+
+                Mobify.combo.exec('cached');
+                equal(wrote, '<script data-orig-src="cached">cached<\/script>');
+
+                Mobify.combo.exec('cached', true);
+                equal(wrote, '<script data-orig-src="cached" src="data:application/x-javascript,cached"><\/script>');
+            } finally {
+                document.write = nativeDocumentWrite;
+            }
         });
 
         asyncTest('httpCache - Eviction on an unused resource', 2, function() {

--- a/tests/index.html
+++ b/tests/index.html
@@ -148,6 +148,10 @@
 /<\/script>/
     </script>
 
+    <script id="test-mobify-combo-exec-document-write-override" type="text/test">
+    document.write = function() {console.log("moo!");};
+    </script>
+
     <script>
         var $ = Mobify.$
           , httpCache = Mobify.httpCache
@@ -306,7 +310,7 @@
             });
         });
 
-        test('Mobify.combo.exec', 5, function() {
+        test('Mobify.combo.exec', 6, function() {
             var cache = {
                 'cached': {
                     'headers': {'expires': UTC_TWO_WEEKS_FROM_NOW},
@@ -320,6 +324,13 @@
                     'status': 'ready',
                     'url': 'cached-with-scripts',
                     'body': getText("#test-mobify-combo-exec"),
+                    'text': true
+                },
+                'override-document-write': {
+                    'headers': {'expires': UTC_TWO_WEEKS_FROM_NOW},
+                    'status' : 'ready',
+                    'url': 'override-document-write',
+                    'body': getText("#test-mobify-combo-exec-document-write-override"),
                     'text': true
                 }
             };
@@ -346,6 +357,13 @@
 
                 Mobify.combo.exec('cached', true);
                 equal(wrote, '<script data-orig-src="cached" src="data:application/x-javascript,cached"><\/script>');
+
+                // test execing a functiont hat overrides a document.write
+                Mobify.combo.exec('override-document-write');
+                equal(wrote, '<script data-orig-src="override-document-write">document.write = function() {console.log("moo!");};<\/script>');
+                // restore regular old document.write after this exec
+                document.write = Mobify.combo._docWrite;
+
             } finally {
                 Mobify.combo._docWrite = origDocWrite;
             }

--- a/tests/index.html
+++ b/tests/index.html
@@ -460,7 +460,7 @@
                 });
             });
 
-        test('httpCache.utils.isStale', 10, function() {
+        test('httpCache.utils.isStale', 12, function() {
             var isStale = httpCache.utils.isStale
               , resources = {
                     'stale-expires': {
@@ -476,6 +476,21 @@
                           , 'cache-control': 'public,max-age=' + TEN_MINUTES
                         }
                     }
+                  , 'no-cache': {
+                        'headers': {
+                            'date': UTC_TWELVE_HOURS_AGO
+                          , 'last-modified': UTC_TWO_WEEKS_AGO
+                          , 'cache-control': 'no-cache'
+                        }
+                    }
+
+                  , 'no-store': {
+                        'headers': {
+                            'date': UTC_TWELVE_HOURS_AGO
+                          , 'last-modified': UTC_TWO_WEEKS_AGO
+                          , 'cache-control': 'no-store'
+                        }
+                  } 
 
                   , 'fresh-expires': {
                         'headers': {
@@ -524,6 +539,8 @@
 
             ok(isStale(resources['stale-expires']));
             ok(isStale(resources['stale-cache-control']));
+            ok(isStale(resources['no-cache']));
+            ok(isStale(resources['no-store']));
             ok(!isStale(resources['fresh-expires']));
             ok(!isStale(resources['fresh-cache-control']));
             ok(isStale(resources['no-headers']), 'No cache headers is stale');

--- a/tests/index.html
+++ b/tests/index.html
@@ -550,7 +550,6 @@
             // Test our ten minute minimum
             ok(!isStale(resources['new-no-cache-headers']), 'No cache headers but less than 10 minutes old');
             // Test ten percent heuristic
-            debugger;
             ok(!isStale(resources['fresh-by-10-percent-heuristic']), 'No cache headers but fresh by last modified 10% heuristic');
 
         });

--- a/tests/index.html
+++ b/tests/index.html
@@ -566,9 +566,9 @@
 
                 ok(true,
                     'meta tag is appended');
-                ok(meta.getAttribute('name'), 'viewport',
+                equal(meta.getAttribute('name'), 'viewport',
                     'meta name is viewport');
-                ok(meta.getAttribute('content'), 'width=device-width',
+                equal(meta.getAttribute('content'), 'width=device-width',
                     'content is width=device-width');
 
                 start();

--- a/tests/index.html
+++ b/tests/index.html
@@ -326,8 +326,8 @@
 
             httpCache.reset(cache);
 
-            var nativeDocumentWrite = document.write
-            document.write = function(s) {
+            var origDocWrite = Mobify.combo._docWrite
+            Mobify.combo._docWrite = function(s) {
                 wrote = s
             }
 
@@ -347,7 +347,7 @@
                 Mobify.combo.exec('cached', true);
                 equal(wrote, '<script data-orig-src="cached" src="data:application/x-javascript,cached"><\/script>');
             } finally {
-                document.write = nativeDocumentWrite;
+                Mobify.combo._docWrite = origDocWrite;
             }
         });
 

--- a/tests/index.html
+++ b/tests/index.html
@@ -186,7 +186,17 @@
         module('combo')
 
         test('Mobify.cssURL - It exists', function() {
-            ok(Mobify.cssURL({}))
+            ok(Mobify.cssURL({}));
+        });
+
+        test('combo - getURL', function() {
+            Mobify.$.fn.combineScripts.defaults.projectName = "foo";
+            var url = Mobify.combo.getURL(["https://www.example.com/baz/qux.js",
+                "http://www.example.com/qux/baz.js"], "bar")
+              , expected = "//jazzcat.mobify.com/project-foo/jsonp/bar/%5B%22http%3A%2F%2Fwww.example.com%2Fqux%2Fbaz.js%22%2C%22https%3A%2F%2Fwww.example.com%2Fbaz%2Fqux.js%22%5D"; 
+
+            
+            equal(url, expected);
         });
 
         asyncTest('combo - Warm cache', 1, function() {

--- a/tests/index.html
+++ b/tests/index.html
@@ -556,7 +556,7 @@
 
         module('util');
 
-        test("ios8_0ScrollFix", function() {
+        test("Mobify.ios8_0ScrollFix", function() {
             var html =
                 "<html>" +
                 "<head>" +

--- a/tests/index.html
+++ b/tests/index.html
@@ -168,7 +168,7 @@
 
             // I don't fit in `localStorage` in Chrome or Safari...
             // But I do seem to fit in FF.
-          , LONG_STRING = Array(5000000).join('1')
+          , LONG_STRING = Array(8000000).join('1')
 
           // One or two will fit in local storage, but not several
           , MEDIUM_STRING = Array(2000000).join('1')
@@ -432,33 +432,33 @@
             }, 0);
         });
 
-            // regression test to ensure Jazzcat evicts more than one itme 
-            // properly when there is too much to store
-            asyncTest('httpCache - Evict until small enough', 2, function() {
-                httpCache.reset();
-                httpCache.save(function(){
-                    for (var i=0; i < 5; i++) {
-                        httpCache.set('val' + i, {'headers': {'expires': UTC_TWO_WEEKS_FROM_NOW}, body: MEDIUM_STRING});
-                        if (i !== 0) {
-                            httpCache.get('val' + i, true);
-                        }
+        // regression test to ensure Jazzcat evicts more than one itme 
+        // properly when there is too much to store
+        asyncTest('httpCache - Evict until small enough', 2, function() {
+            httpCache.reset();
+            httpCache.save(function(){
+                for (var i=0; i < 5; i++) {
+                    httpCache.set('val' + i, {'headers': {'expires': UTC_TWO_WEEKS_FROM_NOW}, body: MEDIUM_STRING});
+                    if (i !== 0) {
+                        httpCache.get('val' + i, true);
                     }
+                }
 
-                    httpCache.save(function(err) {
+                httpCache.save(function(err) {
 
-                        httpCache.reset();
-                        httpCache.load();
+                    httpCache.reset();
+                    httpCache.load();
 
-                        ok(!httpCache.get('val0'), 'val0 was evicted')
-                        ok(!!httpCache.get('val1'), '`val1` was cached');
+                    ok(!httpCache.get('val0'), 'val0 was evicted')
+                    ok(!!httpCache.get('val1'), '`val1` was cached');
 
-                        httpCache.reset();
-                        httpCache.save();
+                    httpCache.reset();
+                    httpCache.save();
 
-                        start();
-                    });
+                    start();
                 });
             });
+        });
 
         test('httpCache.utils.isStale', 12, function() {
             var isStale = httpCache.utils.isStale
@@ -554,6 +554,32 @@
 
         });
 
+        module('util');
+
+        test("ios8_0ScrollFix", function() {
+            var html =
+                "<html>" +
+                "<head>" +
+                "  <title>Scroll Fix Test</title>" +
+                "</head>" +
+                "<body style='font-size: 13px' class='x-test'>" +
+                "  <ul>" +
+                "    <li>Woohoo</li>" +
+                "  </ul>" +
+                "</body>" +
+                "</html>";
+
+            html = Mobify.ios8_0ScrollFix(html);
+            
+            ok(html.indexOf('font-size: 13px') !== -1,
+                '`font-size: 13px` on the body tag is still present');
+            ok(html.indexOf('display: none') !== -1,
+                '`display: none` was set on the body tag');
+            ok(html.indexOf("document.body.style.display = '';") !== -1,
+                'there is a script to show the body');
+            ok(html.indexOf('x-test') !== -1,
+                '`x-test` body class tag is still present');
+        });
 
         module('resizeImages');
 
@@ -637,14 +663,12 @@
             }
         });
 
-
         module('enhance');
 
         test('Mobify.enhance', function() {
             Mobify.enhance();
             ok(1);
         });
-
 
         module('externals')
 
@@ -819,7 +843,7 @@
               "passing the empty object to urlmatch makes it return false");
             equal(urlmatch("/a/b/c")(5), false,
               "passing a number to urlmatch makes it return false");
-        }); //test
+        });
 
         // test('Mobify.html.extractHTML', function() {
         //     var doc = createDocument()

--- a/tests/index.html
+++ b/tests/index.html
@@ -471,7 +471,8 @@
 
                   , 'stale-cache-control': {
                         'headers': {
-                            'date': UTC_TWO_WEEKS_AGO
+                            'date': UTC_TWELVE_HOURS_AGO
+                          , 'last-modified': UTC_TWO_WEEKS_AGO
                           , 'cache-control': 'public,max-age=' + TEN_MINUTES
                         }
                     }
@@ -532,6 +533,7 @@
             // Test our ten minute minimum
             ok(!isStale(resources['new-no-cache-headers']), 'No cache headers but less than 10 minutes old');
             // Test ten percent heuristic
+            debugger;
             ok(!isStale(resources['fresh-by-10-percent-heuristic']), 'No cache headers but fresh by last modified 10% heuristic');
 
         });

--- a/tests/index.html
+++ b/tests/index.html
@@ -168,6 +168,9 @@
             // But I do seem to fit in FF.
           , LONG_STRING = Array(5000000).join('1')
 
+          // One or two will fit in local storage, but not several
+          , MEDIUM_STRING = Array(2000000).join('1')
+
           , getIframeDocument = function(selector) {
                 return $(selector)[0].contentDocument
             }
@@ -347,6 +350,7 @@
 
             httpCache.reset(cache);
 
+            var wrote;
             var origDocWrite = Mobify.combo._docWrite
             Mobify.combo._docWrite = function(s) {
                 wrote = s
@@ -386,7 +390,7 @@
             httpCache.set('unused', {'headers': {'expires': UTC_TWO_WEEKS_FROM_NOW}, body: LONG_STRING})
 
             httpCache.set('used', {'headers': {'expires': UTC_TWO_WEEKS_FROM_NOW}, body: 'used'})
-            httpCache.get('used', true)
+            httpCache.get('used', true); // mark it used
 
             httpCache.save(function(err) {
                 if (err) return;
@@ -426,7 +430,35 @@
             }, 0);
         });
 
-        test('httpCache.utils.isStale', 8, function() {
+            // regression test to ensure Jazzcat evicts more than one itme 
+            // properly when there is too much to store
+            asyncTest('httpCache - Evict until small enough', 2, function() {
+                httpCache.reset();
+                httpCache.save(function(){
+                    for (var i=0; i < 5; i++) {
+                        httpCache.set('val' + i, {'headers': {'expires': UTC_TWO_WEEKS_FROM_NOW}, body: MEDIUM_STRING});
+                        if (i !== 0) {
+                            httpCache.get('val' + i, true);
+                        }
+                    }
+
+                    httpCache.save(function(err) {
+
+                        httpCache.reset();
+                        httpCache.load();
+
+                        ok(!httpCache.get('val0'), 'val0 was evicted')
+                        ok(!!httpCache.get('val1'), '`val1` was cached');
+
+                        httpCache.reset();
+                        httpCache.save();
+
+                        start();
+                    });
+                });
+            });
+
+        test('httpCache.utils.isStale', 9, function() {
             var isStale = httpCache.utils.isStale
               , resources = {
                     'stale-expires': {
@@ -473,7 +505,13 @@
                             'expires': 'invalid'
                         }
                     }
-                };
+                , 'new-no-cache-headers': {
+                    'headers': {
+                        'date': UTC_NOW
+                    }
+                }
+            };
+        
 
             ok(isStale(resources['stale-expires']));
             ok(isStale(resources['stale-cache-control']));
@@ -483,6 +521,8 @@
             ok(isStale(resources['undefined-headers']), 'undefined cache headers is stale');
             ok(isStale(resources['invalid-date']), 'Invalid date is stale');
             ok(isStale(resources['invalid-expires']), 'Invalid expires is stale');
+            // Test our ten minute minimum
+            ok(!isStale(resources['new-no-cache-headers']), 'No cache headers but less than 10 minutes old');
 
         });
 

--- a/tests/runner.sh
+++ b/tests/runner.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -o pipefail
+
 node tests/server.js &
 PID=$!
 

--- a/tests/runner.sh
+++ b/tests/runner.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 node tests/server.js &
 PID=$!
+
 sleep 1
 phantomjs tests/phantom.js | grep '<*>' | tee report.xml
+ret_code=$?
+
 kill $PID
+exit $ret_code

--- a/tests/runner.sh
+++ b/tests/runner.sh
@@ -1,11 +1,9 @@
 #!/bin/bash
-set -o pipefail
-
 node tests/server.js &
 PID=$!
 
 sleep 1
-phantomjs tests/phantom.js | grep '<*>' | tee report.xml
+phantomjs tests/phantom.js
 ret_code=$?
 
 kill $PID

--- a/vendor/dust-core.js
+++ b/vendor/dust-core.js
@@ -448,6 +448,10 @@ dust.helpers = {
 
   idx: function(chunk, context, bodies) {
     return bodies.block(chunk, context.push(context.stack.index));
+  },
+
+  count: function(chunk, context, bodies) {
+    return bodies.block(chunk, context.push(context.stack.index + 1));
   }
 }
 


### PR DESCRIPTION
Removes creating the mobify-path=; cookie; mobify-path is set via preview.

Status: **DO NOT MERGE**\- this branch is for Chewy only until we know if this fixes their issue.

Reviewers: *\* @jansepar @tedtate @johnboxall**
JIRA: https://mobify.atlassian.net/browse/ADJS-87
## Changes
- removed cookie setting code from base.konf
## How to test-drive this PR
- Build yourself a mobify-client using this commit for mobify 1.1
- Build a bundle using the new client
- Preview the bundle and ensure that there's only one cookie set, and its value is `true`, not blank.
