### PR TITLE
Fixed clone command line for installing mobifyjs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Mobify.js uses Bower, Grunt.js and Require.js to build the library, and manage a
 
 And then download the latest code from git and install the dependancies:
 
-    git checkout https://github.com/mobify/mobifyjs.git
+    git clone git@github.com:mobify/mobifyjs.git
     cd mobifyjs
     npm install
     bower install


### PR DESCRIPTION
`git checkout https://github.com/mobify/mobifyjs.git` doesn't work on a non-repo directory:

`fatal: Not a git repository (or any of the parent directories): .git`
