### PR TITLE
Desktop fall-thru issue

### DIFF
--- a/api/cont.js
+++ b/api/cont.js
@@ -116,8 +116,10 @@
                     .evalReference();
             };
 
-            if (typeof source.length === 'number') {
-                $.each(source, eachCallback);
+            if (typeof sourceLength === 'number') {
+                for (i = 0; i < sourceLength; i++) {
+                    eachCallback(i, source[key]);
+                }
             }
             else {
                 for (key in source) {

--- a/api/cont.js
+++ b/api/cont.js
@@ -103,8 +103,8 @@
             var source = this.source(),
                 sourceLength = source.length,
                 continuation = this;
- 
-            $.each(source, function(idx, sourceFragment) {
+
+            var eachCallback = function(idx, sourceFragment) {
                 if (sourceFragment && (sourceFragment.jquery || sourceFragment.nodeType)
                     && (typeof idx == "string") && idx.indexOf('$')) {
                     var root = continuation.root;
@@ -114,7 +114,17 @@
                 continuation
                     .extend({source: sourceFragment}, idx, sourceLength, value)
                     .evalReference();
-            });
+            };
+
+            if (typeof source.length === 'number') {
+                $.each(source, eachCallback);
+            }
+            else {
+                for (key in source) {
+                    eachCallback(key, source[key]);
+                }
+            }
+ 
             return value;
         }
 


### PR DESCRIPTION
## Status: Opened for visibility

We have been trying to solve this issue for awhile. Our clients are reporting that the mobile site have been randomly falling to the desktop state. We had no luck of reproducing this bug so we had no way to figure out what is it that the clients are seeing. It is only until now that we were able to reproduce this bug. Even if we can reproduce it, the chance of reproducing this bug is very low.
### Steps to reproduce the issue
1. VPN to a London access point
2. Navigate normally within mobified pages
3. If you are lucky, you will fall thru to desktop (Chance of 1 in 1000 pageviews)

**Note:** The above steps works with a preview bundle as well but will not work if it is local.
### Investigations

Due to the difficulty of how often we can reproduce this bug, I decided to place debug logging points throughout the code path. In summary, the page that is suppose to be mobified is falling thru because it did not found a matching template.

Further investigation revealed that in the `evalCollection` function, the `$.each` is not iterating the template object.

![screen shot 2015-06-29 at 10 22 58 am](https://cloud.githubusercontent.com/assets/2319002/8440711/e19c91a8-1f28-11e5-85a6-2d8987479d7d.png)

In the above screenshot, I was logging information from the `evalCollection` function.

`source` object is the template object that got pass in from the knof.

The first object with the empty template name is the correct state. Notice that it has 2 object under the source object and we have a boolean indicator `inEachFunction`, to indicate if we arrived in the callback function. `eachFragment` shows how many times that `$.each` callback function is iterated.

The second object with the redirect template name is the incorrect state. Notice that it has 2 objects under the source object, however, the `$.each` callback was never called which is indicated by the false value of `inEachFunction`.

I also make sure that `$.each` and any required objects exists before the `$.each` function.

This PR contains one of the variations of code that I was using to track down the root of the bug. This particular code variation does not fall thru to desktop, at least it hasn't yet.
### Observations

I have been running some number tests to create a baseline that we can compare.

**Without Fix:** Desktop fall thru happens within the range of 0 to 1000 pageviews

**With Fix:** Haven't seen fall thru yet. Highest pageview count is 8715.
### Next Steps
- [x] Test this code on production sites to validate that it does "fix" the desktop fall thru issue (This code is run again Christie's production for 2 weeks so far. We are seeing about maximum of 3 drop thrus comparing to 10-20 drop thrus before fix)

**Participants:** @johnboxall @jansepar @benlast @donnielrt @cbildfell 
## Changes
- Instead of using Zepto's `$.each`, we pull in the exact logic of Zepto's `$.each` to iterate any objects that doesn't have `.length` property
