### PR TITLE
Fix a.js path [1.3.x]

### DIFF
--- a/api/config.js
+++ b/api/config.js
@@ -16,7 +16,7 @@
     // in the v6 tag, ajs is always defined, but that is not the case for v7 tags,
     // and thus we will make it defined here.
     if (Mobify && Mobify.config && Mobify.config.projectName) {
-        Mobify.ajs = Mobify.ajs || '//a.mobify.com/' + Mobify.config.projectName + 'a.js';
+        Mobify.ajs = Mobify.ajs || '//a.mobify.com/' + Mobify.config.projectName + '/a.js';
     }
     config.ajs = Mobify.ajs;
 })();


### PR DESCRIPTION
Status: **Ready for Merge**
Reviewers: @donnielrt @haroldtreen 
## Changes
- Fix bug with constructed a.js path where trailing slash was missing from project slug directory
## Jira Tickets:
- [RTM-434](https://mobify.atlassian.net/browse/RTM-434) 
## Todos:
- [x] +1
### Feedback:

_none so far_
## How to Test
- Check out and `npm link` this branch of mobify-client: https://github.com/mobify/mobify-client/tree/fix-ajs-path
- Now, check out https://github.com/mobify/outrigger-tablet and update the project to 1.3.2
- Run `mobify preview` (using your linked local version) and nothing should blow up
