### PR TITLE
Remove plaintext element for SEO

### DIFF
--- a/api/main.js
+++ b/api/main.js
@@ -36,6 +36,15 @@ $.extend(Mobify.transform, {
     // Read the conf, extract the Source DOM and begin the evaluation.
     prepareConf : function(rawConf) {
         var capturedState = Mobify.html.extractDOM();
+
+        // We need to remove the plaintext element after state is captured
+        // b/c googlebot will think it's the real content
+        // and use it as the SEO content for search result page
+        var plaintextEl = document.querySelector('plaintext')
+        if (plaintextEl) {
+            plaintextEl.parentNode.removeChild(plaintextEl)
+        }
+
         capturedState.config = Mobify.config;
         
         // If conf is using data2 evaluation in a {+conf} or {+konf}, this call would provide


### PR DESCRIPTION
We’ve had a number of projects have SEO issues, due to our capturing logic where a plaintext file is injected into our DOM. Googlebot will occasionally pick that up, and end up showing the contents of the plaintext file versus actual page meta data for the site.

This PR aims to remove the plaintext element as soon as we capture the document.